### PR TITLE
Adds teos crate docs plus some smalls fixes

### DIFF
--- a/teos/src/extended_appointment.rs
+++ b/teos/src/extended_appointment.rs
@@ -5,16 +5,23 @@ use bitcoin::hashes::{ripemd160, Hash};
 use teos_common::appointment::{Appointment, Locator};
 use teos_common::UserId;
 
+/// Unique identifier used to identify appointments.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct UUID(pub [u8; 20]);
 
 impl UUID {
+    /// Creates a new [UUID].
+    ///
+    /// The [UUID]s are created as the `RIPEMD160(locator || user_id)`. This makes it easy to retrieve an [ExtendedAppointment] from the tower
+    /// when a user requests it without having to perform lookups based on the [Locator], and match what [UUID] belongs to what user (if any).
+    /// Therefore, it provides a hard-to-forge id while reducing the tower lookups and the required data to be stored (no reverse maps).
     pub fn new(locator: Locator, user_id: UserId) -> Self {
         let mut uuid_data = locator.serialize();
         uuid_data.extend(&user_id.0.serialize());
         UUID(ripemd160::Hash::hash(&uuid_data).into_inner())
     }
 
+    /// Serializes the [UUID] returning its byte representation.
     pub fn serialize(&self) -> Vec<u8> {
         self.0.to_vec()
     }
@@ -26,20 +33,36 @@ impl std::fmt::Display for UUID {
     }
 }
 
+/// An extended version of the appointment hold by the tower.
+///
+/// The [Appointment] is extended in terms of data, that is, it provides further information only relevant to the tower.
+/// Notice [ExtendedAppointment]s are not kept in memory but persisted on disk. The [Watcher](crate::watcher::Watcher)
+/// keeps [AppointmentSummary] instead.
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct ExtendedAppointment {
+    /// The underlying appointment extended by [ExtendedAppointment].
     pub inner: Appointment,
+    /// The user this [Appointment] belongs to.
     pub user_id: UserId,
+    /// The signature provided by the user when handing the [Appointment].
     pub user_signature: String,
+    /// The block where the [Appointment] is started to be watched at by the [Watcher](crate::watcher::Watcher).
     pub start_block: u32,
 }
 
+/// A summary of an appointment.
+///
+/// Contains the minimal amount of data the [Watcher](crate::watcher::Watcher) needs to keep in memory in order to
+/// watch for breaches.
 pub struct AppointmentSummary {
+    /// The [Appointment] locator.
     pub locator: Locator,
+    /// The user this [Appointment] belongs to.
     pub user_id: UserId,
 }
 
 impl ExtendedAppointment {
+    /// Create a new [ExtendedAppointment].
     pub fn new(
         inner: Appointment,
         user_id: UserId,
@@ -54,18 +77,22 @@ impl ExtendedAppointment {
         }
     }
 
+    /// Gets the underlying appointment's locator.
     pub fn locator(&self) -> Locator {
         self.inner.locator
     }
 
+    /// Gets the underlying appointment's encrypted data blob
     pub fn encrypted_blob(&self) -> &Vec<u8> {
         &self.inner.encrypted_blob
     }
 
+    /// Gets the underlying appointment's `to_self_delay`
     pub fn to_self_delay(&self) -> u32 {
         self.inner.to_self_delay
     }
 
+    /// Computes the summary of the [ExtendedAppointment].
     pub fn get_summary(&self) -> AppointmentSummary {
         AppointmentSummary {
             locator: self.locator(),
@@ -74,6 +101,9 @@ impl ExtendedAppointment {
     }
 }
 
+/// Computes the number of slots an appointment takes from a user subscription.
+///
+/// This is based on the [encrypted_blob](Appointment::encrypted_blob) size and the slot size that was defined by the [Gatekeeper](crate::gatekeeper::Gatekeeper).
 pub fn compute_appointment_slots(blob_size: usize, blob_max_size: usize) -> u32 {
     (blob_size as f32 / blob_max_size as f32).ceil() as u32
 }

--- a/teos/src/lib.rs
+++ b/teos/src/lib.rs
@@ -3,10 +3,12 @@ pub mod carrier;
 pub mod chain_monitor;
 pub mod config;
 pub mod dbm;
+#[doc(hidden)]
 mod errors;
 mod extended_appointment;
 pub mod gatekeeper;
 pub mod responder;
+#[doc(hidden)]
 mod rpc_errors;
 pub mod watcher;
 

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -45,7 +45,7 @@ where
 
 fn create_new_tower_keypair(db: &DBM) -> (SecretKey, PublicKey) {
     let (sk, pk) = get_random_keypair();
-    db.store_key(&sk).unwrap();
+    db.store_tower_key(&sk).unwrap();
     (sk, pk)
 }
 
@@ -57,7 +57,7 @@ pub async fn main() {
     // Create data dir if it does not exist
     fs::create_dir_all(&path).unwrap_or_else(|e| {
         eprint!("Cannot create data dir: {:?}", e);
-        std::process::exit(-1);
+        std::process::exit(1);
     });
 
     // Load conf (from file or defaults) and patch it with the command line parameters received (if any)

--- a/teos/src/rpc_errors.rs
+++ b/teos/src/rpc_errors.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 // Ported from https://github.com/bitcoin/bitcoin/blob/0.18/src/rpc/protocol.h
+// TODO: Check if e can get rid of this whole module once `bitcoincore-rpc` is fully integrated.
 
 // General application defined errors
 pub const RPC_MISC_ERROR: i32 = -1; // std::exception thrown in command handling


### PR DESCRIPTION
 Watcher:
- Modifies ``LocatorCache`` to hold ``BlockHash`` instead of ``BlockHeader``. The headers were not really used for anything aside from checking the hash chain.
- Refactors for loop to use iterators.

Carrier:
- Renames Receipt to DeliveryReceipt

Config:
- Makes `Config::verify` use `bitcoin::network::constants::Network` so code is cleaner and data is parsed from an enum instead of from Strings.

DBM:
- Updates DBM method visibility. Also store_key -> store_tower_key