### PR TITLE
Adds the gRPC server to the tower (InternalAPI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 */target
 Cargo.lock
+.vscode

--- a/teos-common/src/appointment.rs
+++ b/teos-common/src/appointment.rs
@@ -27,7 +27,17 @@ impl Locator {
     }
 }
 
-impl std::fmt::Display for Locator {
+impl std::str::FromStr for Locator {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let raw_locator: Vec<u8> = s.try_into().map_err(|_| "Cannot decode string")?;
+        Locator::deserialize(&raw_locator)
+            .map_err(|_| "Locator cannot be built from the given data".into())
+    }
+}
+
+impl fmt::Display for Locator {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", hex::encode(self.serialize()))
     }
@@ -51,9 +61,34 @@ pub struct Appointment {
 
 /// Represents all the possible states of an appointment in the tower, or in a response to a client request.
 pub enum AppointmentStatus {
-    NotFound,
-    BeingWatched,
-    DisputeResponded,
+    // The ordering here MUST be provided since it matches the one for the protos.
+    NotFound = 0,
+    BeingWatched = 1,
+    DisputeResponded = 2,
+}
+
+impl std::str::FromStr for AppointmentStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "being_watched" => Ok(AppointmentStatus::BeingWatched),
+            "dispute_responded" => Ok(AppointmentStatus::DisputeResponded),
+            "not_found" => Ok(AppointmentStatus::NotFound),
+            _ => Err(format!("Unknown status: {}", s)),
+        }
+    }
+}
+
+impl fmt::Display for AppointmentStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match self {
+            AppointmentStatus::BeingWatched => "being_watched",
+            AppointmentStatus::DisputeResponded => "dispute_responded",
+            AppointmentStatus::NotFound => "not_found",
+        };
+        write!(f, "{}", s)
+    }
 }
 
 impl Appointment {

--- a/teos-common/src/appointment.rs
+++ b/teos-common/src/appointment.rs
@@ -58,9 +58,9 @@ pub enum AppointmentStatus {
 
 impl Appointment {
     /// Creates a new [Appointment] instance.
-    pub fn new(locator: [u8; 16], encrypted_blob: Vec<u8>, to_self_delay: u32) -> Self {
+    pub fn new(locator: Locator, encrypted_blob: Vec<u8>, to_self_delay: u32) -> Self {
         Appointment {
-            locator: Locator(locator),
+            locator,
             encrypted_blob,
             to_self_delay,
         }

--- a/teos-common/src/lib.rs
+++ b/teos-common/src/lib.rs
@@ -27,7 +27,19 @@ impl UserId {
     }
 }
 
-impl std::fmt::Display for UserId {
+impl std::str::FromStr for UserId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        PublicKey::from_str(s)
+            .map_err(|_| {
+                "Provided public key does not match expected format (33-byte hex string)".into()
+            })
+            .map(|pk| Self(pk))
+    }
+}
+
+impl fmt::Display for UserId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }

--- a/teos/Cargo.toml
+++ b/teos/Cargo.toml
@@ -16,6 +16,9 @@ hex = "0.4.3"
 base64 = "0.13.0"
 futures = "0.3"
 log = "0.4"
+tonic = "0.6"
+prost = "0.9"
+prost-types = "0.9"
 simple_logger = "1.12.1"
 serde_json = "1.0"
 rusqlite = {version = "0.26.0", features = ["bundled", "limits"]}
@@ -28,6 +31,9 @@ lightning = { version = "0.0.103", git = "https://github.com/rust-bitcoin/rust-l
 bitcoincore-rpc = "0.13.0"
 
 teos-common = {path = "../teos-common"}
+
+[build-dependencies]
+tonic-build = "0.6"
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/teos/Cargo.toml
+++ b/teos/Cargo.toml
@@ -4,8 +4,13 @@ version = "0.0.1"
 authors = ["Sergi Delgado Segura <sergi.delgado.s@gmail.com>"]
 license = "MIT"
 edition = "2018"
+default-run="rusty-teos"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+
+[[bin]]
+name = "teos-cli"
+path = "src/cli.rs"
 
 [dependencies]
 home = "0.5.3"

--- a/teos/Cargo.toml
+++ b/teos/Cargo.toml
@@ -28,6 +28,8 @@ simple_logger = "1.12.1"
 serde_json = "1.0"
 rusqlite = {version = "0.26.0", features = ["bundled", "limits"]}
 tokio = { version = "1.5", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
+triggered = "0.1.2"
+async-std = "1.10.0"
 
 bitcoin = "0.27"
 lightning-block-sync = {version = "0.0.103", git = "https://github.com/rust-bitcoin/rust-lightning", branch = "main", features = [ "rpc-client" ] }

--- a/teos/build.rs
+++ b/teos/build.rs
@@ -1,0 +1,12 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure().compile(
+        &[
+            "proto/teos/appointment.proto",
+            "proto/teos/tower_services.proto",
+            "proto/teos/user.proto",
+        ],
+        &["proto/teos"],
+    )?;
+
+    Ok(())
+}

--- a/teos/proto/teos/appointment.proto
+++ b/teos/proto/teos/appointment.proto
@@ -1,0 +1,82 @@
+syntax = "proto3";
+package teos.v1;
+
+message Appointment {
+  /*
+  Contains the basic information about an appointment (Watcher) and it's used for messages like
+  AddAppointmentRequest or encapsulated inside AppointmentData for GetAppointmentResponse
+  */
+
+  bytes locator = 1;
+  bytes encrypted_blob = 2;
+  uint32 to_self_delay = 3;
+
+}
+
+message Tracker {
+  // It's the equivalent of an appointment message from data held by the Responder.
+
+  bytes locator = 1;
+  bytes dispute_txid = 2;
+  bytes penalty_txid = 3;
+  bytes penalty_rawtx = 4;
+}
+
+message AppointmentData {
+  /*
+  Encapsulates the data for a GetAppointmentResponse, given it can be an appointment (data is on the Watcher) or a
+  tracker (data is on the Responder).
+  */
+
+  oneof appointment_data {
+    Appointment appointment = 1;
+    Tracker tracker = 2;
+  }
+}
+
+message AddAppointmentRequest {
+  // Request to add an appointment to the backend, contains the appointment data and the user signature.
+
+  Appointment appointment = 1;
+  string signature = 2;
+}
+
+message AddAppointmentResponse {
+  /*
+  Response to an AddAppointmentRequest, contains the locator to identify the added appointment, the tower signature,
+  the block at which the tower has started (or will start) watching for the appointment, and the updated subscription
+  information.
+   */
+
+  bytes locator = 1;
+  uint32 start_block = 2;
+  string signature = 3;
+  uint32 available_slots = 4;
+  uint32 subscription_expiry = 5;
+}
+
+message GetAppointmentRequest {
+  // Request to get information about an appointment. Contains the appointment locator and a signature by the user.
+
+  bytes locator = 1;
+  string signature = 2;
+}
+
+message GetAppointmentResponse {
+  // Response to a GetAppointmentRequest. Contains the appointment data encapsulated in an AppointmentData message.
+
+  AppointmentData appointment_data = 1;
+  enum AppointmentStatus {
+    NOT_FOUND = 0;
+    BEING_WATCHED = 1;
+    DISPUTE_RESPONDED = 2;
+
+  }
+  AppointmentStatus status = 2;
+}
+
+message GetAllAppointmentsResponse {
+  // Response with data about all the appointments in the tower. 
+  
+  repeated AppointmentData appointments = 1;
+}

--- a/teos/proto/teos/tower_services.proto
+++ b/teos/proto/teos/tower_services.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+package teos.v1;
+
+import "appointment.proto";
+import "user.proto";
+import "google/protobuf/empty.proto";
+
+message GetTowerInfoResponse {
+  // Response with information about the tower.
+
+  uint32 n_watcher_appointments = 1;
+  uint32 n_responder_trackers = 2;
+  uint32 n_registered_users = 3;
+  bytes tower_id = 4;
+}
+
+service PublicTowerServices {
+  // Public tower services, only reachable from the public API.
+
+  rpc register(RegisterRequest) returns (RegisterResponse) {}
+  rpc add_appointment(AddAppointmentRequest) returns (AddAppointmentResponse) {}
+  rpc get_appointment(GetAppointmentRequest) returns (GetAppointmentResponse) {}
+  rpc get_subscription_info(GetSubscriptionInfoRequest) returns (GetSubscriptionInfoResponse) {}
+}
+
+service PrivateTowerServices {
+  // Private tower services, only reachable from the private API.
+
+  rpc get_all_appointments(google.protobuf.Empty) returns (GetAllAppointmentsResponse) {}
+  rpc get_tower_info(google.protobuf.Empty) returns (GetTowerInfoResponse) {}
+  rpc get_users(google.protobuf.Empty) returns (GetUsersResponse) {}
+  rpc get_user(GetUserRequest) returns (GetUserResponse) {}
+  rpc stop(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+}

--- a/teos/proto/teos/user.proto
+++ b/teos/proto/teos/user.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+package teos.v1;
+
+message RegisterRequest {
+  // Requests a user registration with the tower. Contains the user id in the form of a compressed ECDSA public key.
+
+  bytes user_id = 1;
+}
+
+message RegisterResponse {
+  // Response to a RegisterRequest, contains the registration information alongside the tower signature of the agreement.
+
+  bytes user_id = 1;
+  uint32 available_slots = 2;
+  uint32 subscription_expiry = 3;
+  string subscription_signature = 4;
+}
+
+message GetUserRequest {
+  // Request to get information about a specific user. Contains the user id.
+
+  bytes user_id = 1;
+}
+
+message GetUserResponse {
+  // Response with the information the tower has about a specific user
+
+  uint32 available_slots = 1;
+  uint32 subscription_expiry = 2;
+  repeated bytes appointments = 3;
+}
+
+message GetUsersResponse {
+  // Response with information about all the users registered with the tower. Contains a list of user ids.
+
+  repeated bytes user_ids = 1;
+}
+
+message GetSubscriptionInfoRequest {
+    // Request to get a specific user's subscription info.
+
+    string signature = 1;
+}
+
+message GetSubscriptionInfoResponse {
+  // Response with the information the tower has about a specific user
+
+  uint32 available_slots = 1;
+  uint32 subscription_expiry = 2;
+  repeated bytes locators = 3;
+}

--- a/teos/src/api.rs
+++ b/teos/src/api.rs
@@ -1,0 +1,281 @@
+use futures::executor::block_on;
+use std::convert::TryInto;
+use std::sync::Arc;
+use tonic::{Code, Request, Response, Status};
+
+use crate::protos as msgs;
+use crate::protos::private_tower_services_server::PrivateTowerServices;
+use crate::protos::public_tower_services_server::PublicTowerServices;
+
+use crate::watcher::{
+    AddAppointmentFailure, AppointmentInfo, GetAppointmentFailure, GetSubscriptionInfoFailure,
+    Watcher,
+};
+
+use teos_common::appointment::{Appointment, AppointmentStatus, Locator};
+use teos_common::UserId;
+
+/// Internal API of the tower.
+/// Holds the [Watcher] (which is the single entry point of the tower's core) and offers interfaces
+/// to all available methods. The [InternalAPI] has two interfaces, a public one, reachable from the [API]
+/// and a private one, only accessible from the [RPCServer].
+pub struct InternalAPI {
+    /// A [Watcher] instance.
+    watcher: Arc<Watcher>,
+}
+
+impl<'a> InternalAPI {
+    /// Creates a new [InternalAPI] instance.
+    pub fn new(watcher: Arc<Watcher>) -> Self {
+        Self { watcher }
+    }
+}
+
+/// Public tower API. Accessible by users.
+#[tonic::async_trait]
+impl<'a> PublicTowerServices for Arc<InternalAPI> {
+    /// Register endpoint. Part of the public API. Internally calls [Watcher::register].
+    async fn register(
+        &self,
+        request: Request<msgs::RegisterRequest>,
+    ) -> Result<Response<msgs::RegisterResponse>, Status> {
+        let req_data = request.into_inner();
+
+        let user_id = UserId::deserialize(&req_data.user_id).map_err(|_| {
+            Status::new(
+                Code::InvalidArgument,
+                "Provided public key does not match expected format (33-byte compressed key)",
+            )
+        })?;
+
+        match self.watcher.register(user_id) {
+            Ok(receipt) => Ok(Response::new(msgs::RegisterResponse {
+                user_id: req_data.user_id,
+                available_slots: receipt.available_slots(),
+                subscription_expiry: receipt.subscription_expiry(),
+                subscription_signature: receipt.signature().unwrap(),
+            })),
+            Err(_) => Err(Status::new(
+                Code::ResourceExhausted,
+                "Subscription maximum slots count reached",
+            )),
+            // FIXME: more errors are needed. e.g. ConnectionRefusedError.
+        }
+    }
+
+    /// Add appointment endpoint. Part of the public API. Internally calls [Watcher::add_appointment].
+    async fn add_appointment(
+        &self,
+        request: Request<msgs::AddAppointmentRequest>,
+    ) -> Result<Response<msgs::AddAppointmentResponse>, Status> {
+        let req_data = request.into_inner();
+        let app_data = req_data.appointment.unwrap();
+
+        let appointment = Appointment::new(
+            Locator::deserialize(&app_data.locator).unwrap(),
+            app_data.encrypted_blob.try_into().unwrap(),
+            app_data.to_self_delay,
+        );
+        let locator = appointment.locator;
+
+        // This is block_on because MutexGuard cannot be sent between threads safely.
+        match block_on(
+            self.watcher
+                .add_appointment(appointment, req_data.signature),
+        ) {
+            Ok((receipt, available_slots, subscription_expiry)) => {
+                Ok(Response::new(msgs::AddAppointmentResponse {
+                    locator: locator.serialize(),
+                    start_block: receipt.start_block(),
+                    signature: receipt.signature().unwrap(),
+                    available_slots,
+                    subscription_expiry,
+                }))
+            }
+            Err(e) => match e {
+                AddAppointmentFailure::AuthenticationFailure
+                | AddAppointmentFailure::NotEnoughSlots => Err(Status::new(
+                    Code::Unauthenticated,
+                    "Invalid signature or user does not have enough slots available",
+                )),
+                AddAppointmentFailure::SubscriptionExpired(x) => Err(Status::new(
+                    Code::Unauthenticated,
+                    format!("Your subscription expired at {}", x),
+                )),
+                AddAppointmentFailure::AlreadyTriggered => Err(Status::new(
+                    Code::AlreadyExists,
+                    "The provided appointment has already been triggered",
+                )),
+                // FIXME: more errors are needed. e.g. ConnectionRefusedError.
+            },
+        }
+    }
+
+    /// Get appointment endpoint. Part of the public API. Internally calls [Watcher::get_appointment].
+    async fn get_appointment(
+        &self,
+        request: Request<msgs::GetAppointmentRequest>,
+    ) -> Result<Response<msgs::GetAppointmentResponse>, Status> {
+        let req_data = request.into_inner();
+        let locator = Locator::deserialize(&req_data.locator).unwrap();
+
+        match self.watcher.get_appointment(locator, &req_data.signature) {
+            Ok(info) => {
+                let (appointment_data, status) = match info {
+                    AppointmentInfo::Appointment(appointment) => (
+                        msgs::AppointmentData {
+                            appointment_data: Some(
+                                msgs::appointment_data::AppointmentData::Appointment(
+                                    appointment.into(),
+                                ),
+                            ),
+                        },
+                        AppointmentStatus::BeingWatched,
+                    ),
+                    AppointmentInfo::Tracker(tracker) => (
+                        msgs::AppointmentData {
+                            appointment_data: Some(
+                                msgs::appointment_data::AppointmentData::Tracker(tracker.into()),
+                            ),
+                        },
+                        AppointmentStatus::DisputeResponded,
+                    ),
+                };
+                Ok(Response::new(msgs::GetAppointmentResponse {
+                    appointment_data: Some(appointment_data),
+                    status: status as i32,
+                }))
+            }
+            Err(e) => match e {
+                GetAppointmentFailure::AuthenticationFailure | GetAppointmentFailure::NotFound => {
+                    Err(Status::new(Code::NotFound, "Appointment not found"))
+                }
+                GetAppointmentFailure::SubscriptionExpired(x) => Err(Status::new(
+                    Code::Unauthenticated,
+                    format!("Your subscription expired at {}", x),
+                )),
+                // FIXME: more errors are needed. e.g. ConnectionRefusedError.
+            },
+        }
+    }
+
+    /// Get subscription info endpoint. Part of the public API. Internally calls [Watcher::get_subscription_info].
+    async fn get_subscription_info(
+        &self,
+        request: Request<msgs::GetSubscriptionInfoRequest>,
+    ) -> Result<Response<msgs::GetSubscriptionInfoResponse>, Status> {
+        let (subscription_info, locators) = self
+            .watcher
+            .get_subscription_info(&request.into_inner().signature)
+            .map_err(|e| match e {
+                GetSubscriptionInfoFailure::AuthenticationFailure => {
+                    Status::new(Code::NotFound, "User not found. Have you registered?")
+                }
+                GetSubscriptionInfoFailure::SubscriptionExpired(x) => Status::new(
+                    Code::Unauthenticated,
+                    format!("Your subscription expired at {}", x),
+                ),
+                // FIXME: more errors are needed. e.g. ConnectionRefusedError.
+            })?;
+
+        Ok(Response::new(msgs::GetSubscriptionInfoResponse {
+            available_slots: subscription_info.available_slots,
+            subscription_expiry: subscription_info.subscription_expiry,
+            locators: locators.iter().map(|x| x.serialize()).collect(),
+        }))
+    }
+}
+
+/// Private tower API. Only accessible by the tower admin via RPC.
+#[tonic::async_trait]
+impl<'a> PrivateTowerServices for Arc<InternalAPI> {
+    /// Get all appointments endpoint. Gets all appointments in the tower. Part of the private API.
+    /// Internally calls [Watcher::get_all_watcher_appointments] and [Watcher::get_all_responder_trackers].
+    async fn get_all_appointments(
+        &self,
+        _: Request<()>,
+    ) -> Result<Response<msgs::GetAllAppointmentsResponse>, Status> {
+        let mut all_appointments = Vec::new();
+
+        for (_, appointment) in self.watcher.get_all_watcher_appointments().into_iter() {
+            all_appointments.push(msgs::AppointmentData {
+                appointment_data: Some(msgs::appointment_data::AppointmentData::Appointment(
+                    appointment.inner.into(),
+                )),
+            })
+        }
+
+        for (_, tracker) in self.watcher.get_all_responder_trackers().into_iter() {
+            all_appointments.push(msgs::AppointmentData {
+                appointment_data: Some(msgs::appointment_data::AppointmentData::Tracker(
+                    tracker.into(),
+                )),
+            })
+        }
+
+        Ok(Response::new(msgs::GetAllAppointmentsResponse {
+            appointments: all_appointments,
+        }))
+    }
+
+    /// Get tower info endpoint. Gets information about the tower state. Part of the private API.
+    /// Internally calls [Watcher::get_registered_users_count], [Watcher::get_appointments_count]
+    /// and [Watcher::get_trackers_count].
+    async fn get_tower_info(
+        &self,
+        _: Request<()>,
+    ) -> Result<Response<msgs::GetTowerInfoResponse>, Status> {
+        Ok(Response::new(msgs::GetTowerInfoResponse {
+            tower_id: self.watcher.tower_id.serialize(),
+            n_registered_users: self.watcher.get_registered_users_count() as u32,
+            n_watcher_appointments: self.watcher.get_appointments_count() as u32,
+            n_responder_trackers: self.watcher.get_trackers_count() as u32,
+        }))
+    }
+
+    /// Get user endpoint. Gets all users in the tower. Part of the private API.
+    /// Internally calls [Watcher::get_user_ids].
+    async fn get_users(&self, _: Request<()>) -> Result<Response<msgs::GetUsersResponse>, Status> {
+        let user_ids = self
+            .watcher
+            .get_user_ids()
+            .iter()
+            .map(|x| x.serialize())
+            .collect();
+
+        Ok(Response::new(msgs::GetUsersResponse { user_ids }))
+    }
+
+    /// Get user endpoint. Gets information about a given user. Part of the private API.
+    /// Internally calls [Watcher::get_user].
+    async fn get_user(
+        &self,
+        request: Request<msgs::GetUserRequest>,
+    ) -> Result<Response<msgs::GetUserResponse>, Status> {
+        let user_id = UserId::deserialize(&request.into_inner().user_id).map_err(|_| {
+            Status::new(
+                Code::InvalidArgument,
+                "Provided public key does not match expected format (33-byte compressed key)",
+            )
+        })?;
+
+        match self.watcher.get_user_info(user_id) {
+            Some(info) => Ok(Response::new(msgs::GetUserResponse {
+                available_slots: info.available_slots,
+                subscription_expiry: info.subscription_expiry,
+                appointments: info
+                    .appointments
+                    .iter()
+                    .map(|(uuid, _)| uuid.serialize())
+                    .collect(),
+            })),
+            None => Err(Status::new(Code::NotFound, "User not found")),
+        }
+    }
+
+    /// Stop endpoint. Stops the tower daemon. Part of the private API.
+    // FIXME: Not implemented yet. Needs to perform a gentle shutdown of the whole system.
+    async fn stop(&self, _: Request<()>) -> Result<Response<()>, Status> {
+        Ok(Response::new(()))
+    }
+}

--- a/teos/src/api.rs
+++ b/teos/src/api.rs
@@ -286,3 +286,694 @@ impl<'a> PrivateTowerServices for Arc<InternalAPI> {
         Ok(Response::new(()))
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    use crate::dbm::DBM;
+    use crate::gatekeeper::Gatekeeper;
+    use crate::test_utils::{
+        create_responder, create_watcher, BitcoindMock, Blockchain, MockOptions, EXPIRY_DELTA,
+        START_HEIGHT,
+    };
+
+    pub(super) async fn create_api(slots: u32, duration: u32) -> Arc<InternalAPI> {
+        let bitcoind_mock = BitcoindMock::new(MockOptions::empty());
+        let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
+
+        let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
+        let gk = Arc::new(Gatekeeper::new(
+            chain.tip(),
+            slots,
+            duration,
+            EXPIRY_DELTA,
+            dbm.clone(),
+        ));
+        let responder = create_responder(chain.tip(), gk.clone(), dbm.clone(), bitcoind_mock.url());
+        let watcher = create_watcher(
+            &mut chain,
+            Arc::new(responder),
+            gk.clone(),
+            bitcoind_mock,
+            dbm.clone(),
+        )
+        .await;
+
+        let (shutdown_trigger, _) = triggered::trigger();
+        Arc::new(InternalAPI::new(Arc::new(watcher), shutdown_trigger))
+    }
+}
+#[cfg(test)]
+mod tests_private_api {
+    use super::tests::create_api;
+    use super::*;
+
+    use crate::extended_appointment::UUID;
+    use crate::test_utils::{generate_dummy_appointment, DURATION, SLOTS, START_HEIGHT};
+    use teos_common::cryptography::{self, get_random_keypair};
+
+    #[tokio::test]
+    async fn test_get_all_appointments() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        let response = internal_api
+            .get_all_appointments(Request::new(()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(matches!(response, msgs::GetAllAppointmentsResponse { .. }))
+    }
+
+    #[tokio::test]
+    async fn test_get_all_appointments_watcher() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // Add data to the Watcher so we can retrieve it later on
+        let (user_sk, user_pk) = get_random_keypair();
+        internal_api.watcher.register(UserId(user_pk)).unwrap();
+
+        let appointment = generate_dummy_appointment(None).inner;
+        let user_signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+        internal_api
+            .watcher
+            .add_appointment(appointment.clone(), user_signature)
+            .await
+            .unwrap();
+
+        let response = internal_api
+            .get_all_appointments(Request::new(()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.appointments.len(), 1);
+        assert!(matches!(
+            response.appointments[0].appointment_data,
+            Some(msgs::appointment_data::AppointmentData::Appointment { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_all_appointments_responder() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // Add data to the Responser so we can retrieve it later on
+        let (_, user_pk) = get_random_keypair();
+        let user_id = UserId(user_pk);
+        internal_api.watcher.register(user_id).unwrap();
+
+        let appointment = generate_dummy_appointment(None).inner;
+        internal_api
+            .watcher
+            .add_random_tracker_to_responder(UUID::new(appointment.locator, user_id));
+
+        let response = internal_api
+            .get_all_appointments(Request::new(()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.appointments.len(), 1);
+        assert!(matches!(
+            response.appointments[0].appointment_data,
+            Some(msgs::appointment_data::AppointmentData::Tracker { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_tower_info_empty() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        let response = internal_api
+            .get_tower_info(Request::new(()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.tower_id, internal_api.watcher.tower_id.serialize());
+        assert_eq!(response.n_registered_users, 0);
+        assert_eq!(response.n_watcher_appointments, 0);
+        assert_eq!(response.n_responder_trackers, 0);
+    }
+
+    #[tokio::test]
+    async fn test_get_tower_info() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // Register a user
+        let (user_sk, user_pk) = get_random_keypair();
+        let user_id = UserId(user_pk);
+        internal_api.watcher.register(user_id).unwrap();
+
+        // Add data to the Watcher
+        for _ in 0..2 {
+            let appointment = generate_dummy_appointment(None).inner;
+            let user_signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+            internal_api
+                .watcher
+                .add_appointment(appointment.clone(), user_signature)
+                .await
+                .unwrap();
+        }
+
+        // And the Responder
+        for _ in 0..3 {
+            let appointment = generate_dummy_appointment(None).inner;
+            internal_api
+                .watcher
+                .add_random_tracker_to_responder(UUID::new(appointment.locator, user_id));
+        }
+
+        let response = internal_api
+            .get_tower_info(Request::new(()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        // Given get_tower_info checks data in memory, the data added to the Responder in the test won't be added to the Watcher too.
+        assert_eq!(response.tower_id, internal_api.watcher.tower_id.serialize());
+        assert_eq!(response.n_registered_users, 1);
+        assert_eq!(response.n_watcher_appointments, 2);
+        assert_eq!(response.n_responder_trackers, 3);
+    }
+
+    #[tokio::test]
+    async fn test_get_users() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+        let mut users = Vec::new();
+
+        // Add a couple of users
+        for _ in 0..2 {
+            let (_, user_pk) = get_random_keypair();
+            let user_id = UserId(user_pk);
+            internal_api.watcher.register(user_id).unwrap();
+            users.push(user_id.serialize());
+        }
+
+        let mut response = internal_api
+            .get_users(Request::new(()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.user_ids.sort(), users.sort());
+    }
+
+    #[tokio::test]
+    async fn test_get_users_empty() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        let response = internal_api
+            .get_users(Request::new(()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(response.user_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_user() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // Register a user and get it back
+        let (user_sk, user_pk) = get_random_keypair();
+        let user_id = UserId(user_pk);
+        internal_api.watcher.register(user_id).unwrap();
+
+        let response = internal_api
+            .get_user(Request::new(msgs::GetUserRequest {
+                user_id: user_id.serialize(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.available_slots, SLOTS);
+        assert_eq!(response.subscription_expiry, START_HEIGHT as u32 + DURATION);
+        assert!(response.appointments.is_empty());
+
+        // Add an appointment and check back
+        let appointment = generate_dummy_appointment(None).inner;
+        let uuid = UUID::new(appointment.locator, user_id);
+        let user_signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+        internal_api
+            .watcher
+            .add_appointment(appointment.clone(), user_signature)
+            .await
+            .unwrap();
+
+        let response = internal_api
+            .get_user(Request::new(msgs::GetUserRequest {
+                user_id: user_id.serialize(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.available_slots, SLOTS - 1);
+        assert_eq!(response.subscription_expiry, START_HEIGHT as u32 + DURATION);
+        assert_eq!(response.appointments, Vec::from([uuid.serialize()]));
+    }
+
+    #[tokio::test]
+    async fn test_get_user_not_found() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // Non-registered user
+        let (_, user_pk) = get_random_keypair();
+
+        match internal_api
+            .get_user(Request::new(msgs::GetUserRequest {
+                user_id: UserId(user_pk).serialize(),
+            }))
+            .await
+        {
+            Err(status) => {
+                assert_eq!(status.code(), Code::NotFound);
+                assert_eq!(status.message(), "User not found")
+            }
+            _ => panic!("Test should have returned Err"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stop() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        assert!(!internal_api.shutdown_trigger.is_triggered());
+        internal_api.stop(Request::new(())).await.unwrap();
+        assert!(internal_api.shutdown_trigger.is_triggered());
+    }
+}
+
+#[cfg(test)]
+mod tests_public_api {
+    use super::tests::create_api;
+    use super::*;
+
+    use crate::extended_appointment::UUID;
+    use crate::test_utils::{generate_dummy_appointment, DURATION, SLOTS};
+    use teos_common::cryptography::{self, get_random_keypair};
+
+    #[tokio::test]
+    async fn test_register() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        let (_, user_pk) = get_random_keypair();
+
+        // Registering (even multiple times) should work
+        for _ in 0..2 {
+            let response = internal_api
+                .register(Request::new(msgs::RegisterRequest {
+                    user_id: UserId(user_pk).serialize(),
+                }))
+                .await
+                .unwrap()
+                .into_inner();
+
+            assert!(matches!(response, msgs::RegisterResponse { .. }))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_register_wrong_user_id() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        let mut user_ids = Vec::new();
+
+        // Wrong user id size
+        let (_, user_pk) = get_random_keypair();
+        let mut user_id_vec = UserId(user_pk).serialize();
+        user_id_vec.pop();
+        user_ids.push(user_id_vec);
+
+        // Wrong format (does not start with 2 nor 3)
+        user_id_vec = UserId(user_pk).serialize();
+        user_id_vec[0] = 1;
+        user_ids.push(user_id_vec);
+
+        for user_id in user_ids {
+            match internal_api
+                .register(Request::new(msgs::RegisterRequest { user_id }))
+                .await
+            {
+                Err(status) => {
+                    assert_eq!(status.code(), Code::InvalidArgument);
+                    assert_eq!(status.message(), "Provided public key does not match expected format (33-byte compressed key)")
+                }
+                _ => panic!("Test should have returned Err"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_register_max_slots() {
+        let internal_api = create_api(u32::MAX, DURATION).await;
+
+        let (_, user_pk) = get_random_keypair();
+        let user_id = UserId(user_pk).serialize();
+
+        // First registration should go trough
+        internal_api
+            .register(Request::new(msgs::RegisterRequest {
+                user_id: user_id.clone(),
+            }))
+            .await
+            .unwrap();
+
+        // Trying to add more slots (re-register) must fail
+        match internal_api
+            .register(Request::new(msgs::RegisterRequest { user_id }))
+            .await
+        {
+            Err(status) => {
+                assert_eq!(status.code(), Code::ResourceExhausted);
+                assert_eq!(status.message(), "Subscription maximum slots count reached")
+            }
+            _ => panic!("Test should have returned Err"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_add_appointment() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // User must be registered
+        let (user_sk, user_pk) = get_random_keypair();
+        internal_api.watcher.register(UserId(user_pk)).unwrap();
+
+        let appointment = generate_dummy_appointment(None).inner;
+        let user_signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+
+        let response = internal_api
+            .add_appointment(Request::new(msgs::AddAppointmentRequest {
+                appointment: Some(appointment.clone().into()),
+                signature: user_signature.clone(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(matches!(response, msgs::AddAppointmentResponse { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_add_appointment_non_registered() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // User is not registered this time
+        let (user_sk, _) = get_random_keypair();
+
+        let appointment = generate_dummy_appointment(None).inner;
+        let user_signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+
+        match internal_api
+            .add_appointment(Request::new(msgs::AddAppointmentRequest {
+                appointment: Some(appointment.clone().into()),
+                signature: user_signature.clone(),
+            }))
+            .await
+        {
+            Err(status) => {
+                assert_eq!(status.code(), Code::Unauthenticated);
+                assert_eq!(
+                    status.message(),
+                    "Invalid signature or user does not have enough slots available"
+                )
+            }
+            _ => panic!("Test should have returned Err"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_add_appointment_not_enough_slots() {
+        let internal_api = create_api(0, DURATION).await;
+
+        // User is registered but has no slots
+        let (user_sk, user_pk) = get_random_keypair();
+        internal_api.watcher.register(UserId(user_pk)).unwrap();
+
+        let appointment = generate_dummy_appointment(None).inner;
+        let user_signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+
+        match internal_api
+            .add_appointment(Request::new(msgs::AddAppointmentRequest {
+                appointment: Some(appointment.clone().into()),
+                signature: user_signature.clone(),
+            }))
+            .await
+        {
+            Err(status) => {
+                assert_eq!(status.code(), Code::Unauthenticated);
+                assert_eq!(
+                    status.message(),
+                    "Invalid signature or user does not have enough slots available"
+                )
+            }
+            _ => panic!("Test should have returned Err"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_add_appointment_subscription_expired() {
+        let internal_api = create_api(SLOTS, 0).await;
+
+        // User is registered but subscription is expired
+        let (user_sk, user_pk) = get_random_keypair();
+        internal_api.watcher.register(UserId(user_pk)).unwrap();
+
+        let appointment = generate_dummy_appointment(None).inner;
+        let user_signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+
+        match internal_api
+            .add_appointment(Request::new(msgs::AddAppointmentRequest {
+                appointment: Some(appointment.clone().into()),
+                signature: user_signature.clone(),
+            }))
+            .await
+        {
+            Err(status) => {
+                assert_eq!(status.code(), Code::Unauthenticated);
+                assert!(status.message().starts_with("Your subscription expired at"),)
+            }
+            _ => panic!("Test should have returned Err"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_add_appointment_already_triggered() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // User is registered but subscription is expired
+        let (user_sk, user_pk) = get_random_keypair();
+        let user_id = UserId(user_pk);
+        internal_api.watcher.register(user_id).unwrap();
+
+        let appointment = generate_dummy_appointment(None).inner;
+        let user_signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+        internal_api
+            .watcher
+            .add_random_tracker_to_responder(UUID::new(appointment.locator, user_id));
+
+        match internal_api
+            .add_appointment(Request::new(msgs::AddAppointmentRequest {
+                appointment: Some(appointment.clone().into()),
+                signature: user_signature.clone(),
+            }))
+            .await
+        {
+            Err(status) => {
+                assert_eq!(status.code(), Code::AlreadyExists);
+                assert!(status
+                    .message()
+                    .starts_with("The provided appointment has already been triggered"),)
+            }
+            _ => panic!("Test should have returned Err"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_appointment() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // The user must be registered
+        let (user_sk, user_pk) = get_random_keypair();
+        internal_api.watcher.register(UserId(user_pk)).unwrap();
+
+        // Add the appointment
+        let appointment = generate_dummy_appointment(None).inner;
+        let user_signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+        internal_api
+            .watcher
+            .add_appointment(appointment.clone(), user_signature)
+            .await
+            .unwrap();
+
+        // Get the appointment through the API
+        let message = format!("get appointment {}", appointment.locator);
+        let response = internal_api
+            .get_appointment(Request::new(msgs::GetAppointmentRequest {
+                locator: appointment.locator.serialize(),
+                signature: cryptography::sign(message.as_bytes(), &user_sk).unwrap(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(matches!(response, msgs::GetAppointmentResponse { .. }))
+    }
+
+    #[tokio::test]
+    async fn test_get_appointment_non_registered() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // Add a first user to link the appointment to him
+        let (user_sk, user_pk) = get_random_keypair();
+        internal_api.watcher.register(UserId(user_pk)).unwrap();
+
+        // There's no need to add the appointment given the subscription status is checked first
+        let appointment = generate_dummy_appointment(None).inner;
+
+        // Try to get the appointment through the API
+        let message = format!("get appointment {}", appointment.locator);
+        match internal_api
+            .get_appointment(Request::new(msgs::GetAppointmentRequest {
+                locator: appointment.locator.serialize(),
+                signature: cryptography::sign(message.as_bytes(), &user_sk).unwrap(),
+            }))
+            .await
+        {
+            Err(status) => {
+                assert_eq!(status.code(), Code::NotFound);
+                assert_eq!(status.message(), "Appointment not found");
+            }
+            _ => (),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_appointment_non_existent() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // The user is registered but the appointment does not exist
+        let (user_sk, user_pk) = get_random_keypair();
+        internal_api.watcher.register(UserId(user_pk)).unwrap();
+
+        // Try to get the appointment through the API
+        let appointment = generate_dummy_appointment(None).inner;
+        let message = format!("get appointment {}", appointment.locator);
+
+        match internal_api
+            .get_appointment(Request::new(msgs::GetAppointmentRequest {
+                locator: appointment.locator.serialize(),
+                signature: cryptography::sign(message.as_bytes(), &user_sk).unwrap(),
+            }))
+            .await
+        {
+            Err(status) => {
+                assert_eq!(status.code(), Code::NotFound);
+                assert_eq!(status.message(), "Appointment not found");
+            }
+            _ => (),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_appointment_subscription_expired() {
+        let internal_api = create_api(SLOTS, 0).await;
+
+        // Register the user
+        let (user_sk, user_pk) = get_random_keypair();
+        internal_api.watcher.register(UserId(user_pk)).unwrap();
+
+        // There s no need to add the appointment given the subscription status is checked first.
+        let appointment = generate_dummy_appointment(None).inner;
+
+        // Try to get the appointment through the API
+        let message = format!("get appointment {}", appointment.locator);
+        match internal_api
+            .get_appointment(Request::new(msgs::GetAppointmentRequest {
+                locator: appointment.locator.serialize(),
+                signature: cryptography::sign(message.as_bytes(), &user_sk).unwrap(),
+            }))
+            .await
+        {
+            Err(status) => {
+                assert_eq!(status.code(), Code::Unauthenticated);
+                assert!(status.message().starts_with("Your subscription expired at"));
+            }
+            _ => (),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_subscription_info() {
+        let internal_api = create_api(SLOTS, DURATION).await;
+
+        // The user must be registered
+        let (user_sk, user_pk) = get_random_keypair();
+        internal_api.watcher.register(UserId(user_pk)).unwrap();
+
+        // Get the subscription info though the API
+        let message = format!("get subscription info");
+        let response = internal_api
+            .get_subscription_info(Request::new(msgs::GetSubscriptionInfoRequest {
+                signature: cryptography::sign(message.as_bytes(), &user_sk).unwrap(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(matches!(response, msgs::GetSubscriptionInfoResponse { .. }))
+    }
+
+    #[tokio::test]
+    async fn test_get_subscription_info_non_registered() {
+        let internal_api = create_api(SLOTS, 0).await;
+
+        // The user is not registered
+        let (user_sk, _) = get_random_keypair();
+
+        // Try to get the subscription info though the API
+        let message = format!("get subscription info");
+        match internal_api
+            .get_subscription_info(Request::new(msgs::GetSubscriptionInfoRequest {
+                signature: cryptography::sign(message.as_bytes(), &user_sk).unwrap(),
+            }))
+            .await
+        {
+            Err(status) => {
+                assert_eq!(status.code(), Code::NotFound);
+                assert_eq!(status.message(), "User not found. Have you registered?");
+            }
+            _ => (),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_subscription_info_expired() {
+        let internal_api = create_api(SLOTS, 0).await;
+
+        // The user is registered but the subscription has expired
+        let (user_sk, user_pk) = get_random_keypair();
+        internal_api.watcher.register(UserId(user_pk)).unwrap();
+
+        // Try to get the subscription info though the API
+        let message = format!("get subscription info");
+        match internal_api
+            .get_subscription_info(Request::new(msgs::GetSubscriptionInfoRequest {
+                signature: cryptography::sign(message.as_bytes(), &user_sk).unwrap(),
+            }))
+            .await
+        {
+            Err(status) => {
+                assert_eq!(status.code(), Code::Unauthenticated);
+                assert!(status.message().starts_with("Your subscription expired at"));
+            }
+            _ => (),
+        }
+    }
+}

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -131,6 +131,10 @@ pub struct Config {
     pub subscription_duration: u32,
     pub expiry_delta: u32,
     pub min_to_self_delay: u16,
+
+    // Internal API
+    pub internal_api_bind: String,
+    pub internal_api_port: u32,
 }
 
 impl Config {
@@ -241,14 +245,14 @@ impl Default for Config {
     /// user does not use any values provided here).
     fn default() -> Self {
         Self {
-            api_bind: "localhost".to_owned(),
+            api_bind: "localhost".into(),
             api_port: 9814,
-            rpc_bind: "localhost".to_owned(),
+            rpc_bind: "localhost".into(),
             rpc_port: 8814,
-            btc_network: "bitcoin".to_owned(),
+            btc_network: "bitcoin".into(),
             btc_rpc_user: String::new(),
             btc_rpc_password: String::new(),
-            btc_rpc_connect: "localhost".to_owned(),
+            btc_rpc_connect: "localhost".into(),
             btc_rpc_port: 0,
             daemon: false,
             debug: false,
@@ -257,6 +261,8 @@ impl Default for Config {
             subscription_duration: 4320,
             expiry_delta: 6,
             min_to_self_delay: 20,
+            internal_api_bind: "127.0.0.1".into(),
+            internal_api_port: 50051,
         }
     }
 }

--- a/teos/src/dbm.rs
+++ b/teos/src/dbm.rs
@@ -337,7 +337,7 @@ impl DBM {
 
         stmt.query_row([key], |row| {
             let raw_locator: Vec<u8> = row.get(1).unwrap();
-            let locator: [u8; 16] = raw_locator[0..16].try_into().unwrap();
+            let locator = Locator::deserialize(&raw_locator).unwrap();
             let raw_userid: Vec<u8> = row.get(6).unwrap();
             let user_id = UserId::deserialize(&raw_userid).unwrap();
 
@@ -365,7 +365,7 @@ impl DBM {
             let raw_uuid: Vec<u8> = row.get(0).unwrap();
             let uuid = UUID::deserialize(&raw_uuid[0..20]).unwrap();
             let raw_locator: Vec<u8> = row.get(1).unwrap();
-            let locator: [u8; 16] = raw_locator[0..16].try_into().unwrap();
+            let locator = Locator::deserialize(&raw_locator).unwrap();
             let raw_userid: Vec<u8> = row.get(6).unwrap();
             let user_id = UserId::deserialize(&raw_userid).unwrap();
 

--- a/teos/src/dbm.rs
+++ b/teos/src/dbm.rs
@@ -904,7 +904,7 @@ mod tests {
         tracker.locator = appointment.locator();
         assert!(matches!(dbm.store_tracker(uuid, &tracker), Ok { .. }));
 
-        // Try to store it again, but it shouldn't go trough
+        // Try to store it again, but it shouldn't go through
         assert!(matches!(
             dbm.store_tracker(uuid, &tracker),
             Err(Error::AlreadyExists)

--- a/teos/src/dbm.rs
+++ b/teos/src/dbm.rs
@@ -2,7 +2,6 @@
 //!
 
 use std::collections::{HashMap, HashSet};
-use std::convert::TryInto;
 use std::path::PathBuf;
 use std::str::FromStr;
 

--- a/teos/src/extended_appointment.rs
+++ b/teos/src/extended_appointment.rs
@@ -120,7 +120,6 @@ pub fn compute_appointment_slots(blob_size: usize, blob_max_size: usize) -> u32 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::TryInto;
 
     use crate::test_utils::get_random_user_id;
     use teos_common::appointment::Appointment;
@@ -128,7 +127,7 @@ mod tests {
 
     #[test]
     fn test_get_summary() {
-        let locator = get_random_bytes(16).try_into().unwrap();
+        let locator = Locator::deserialize(&get_random_bytes(16)).unwrap();
         let user_id = get_random_user_id();
         let signature = String::new();
 

--- a/teos/src/extended_appointment.rs
+++ b/teos/src/extended_appointment.rs
@@ -1,11 +1,13 @@
 //! Logic related to appointments handled by the tower.
 
+use hex;
 use std::array::TryFromSliceError;
 use std::convert::TryInto;
 use std::fmt;
 
 use bitcoin::hashes::{ripemd160, Hash};
 
+use crate::protos as msgs;
 use teos_common::appointment::{Appointment, Locator};
 use teos_common::UserId;
 
@@ -106,6 +108,16 @@ impl ExtendedAppointment {
         AppointmentSummary {
             locator: self.locator(),
             user_id: self.user_id,
+        }
+    }
+}
+
+impl Into<msgs::Appointment> for Appointment {
+    fn into(self) -> msgs::Appointment {
+        msgs::Appointment {
+            locator: self.locator.serialize(),
+            encrypted_blob: self.encrypted_blob.clone(),
+            to_self_delay: self.to_self_delay,
         }
     }
 }

--- a/teos/src/gatekeeper.rs
+++ b/teos/src/gatekeeper.rs
@@ -98,6 +98,30 @@ impl Gatekeeper {
         }
     }
 
+    /// Ges the number of users currently registered to the tower.
+    pub fn get_registered_users_count(&self) -> usize {
+        self.registered_users.lock().unwrap().len()
+    }
+
+    /// Gets the list of all registered user ids.
+    pub fn get_user_ids(&self) -> Vec<UserId> {
+        self.registered_users
+            .lock()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    /// Gets the data held by the tower about a given user.
+    pub fn get_user_info(&self, user_id: UserId) -> Option<UserInfo> {
+        self.registered_users
+            .lock()
+            .unwrap()
+            .get(&user_id)
+            .map(|x| x.clone())
+    }
+
     /// Authenticates a user.
     ///
     /// User authentication is performed using ECRecover against fixed messages (one for each command).

--- a/teos/src/gatekeeper.rs
+++ b/teos/src/gatekeeper.rs
@@ -1,6 +1,5 @@
 //! Logic related to the Gatekeeper, the component in charge of managing access to the tower resources.
 
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use std::sync::{Arc, Mutex};
@@ -70,10 +69,10 @@ pub struct Gatekeeper {
     /// Grace period given to renew subscriptions, in blocks.
     expiry_delta: u32,
     /// Map of users registered within the tower.
-    registered_users: RefCell<HashMap<UserId, UserInfo>>,
+    registered_users: Mutex<HashMap<UserId, UserInfo>>,
     /// Map of users whose subscription has been outdated. Kept around so other components can perform the necessary
     /// cleanups when deleting data.
-    outdated_users_cache: RefCell<HashMap<u32, HashMap<UserId, Vec<UUID>>>>,
+    outdated_users_cache: Mutex<HashMap<u32, HashMap<UserId, Vec<UUID>>>>,
     /// A [DBM] (database manager) instance. Used to persist appointment data into disk.
     dbm: Arc<Mutex<DBM>>,
 }
@@ -93,8 +92,8 @@ impl Gatekeeper {
             subscription_slots,
             subscription_duration,
             expiry_delta,
-            registered_users: RefCell::new(HashMap::new()),
-            outdated_users_cache: RefCell::new(HashMap::new()),
+            registered_users: Mutex::new(HashMap::new()),
+            outdated_users_cache: Mutex::new(HashMap::new()),
             dbm,
         }
     }
@@ -113,7 +112,7 @@ impl Gatekeeper {
                 .map_err(|_| AuthenticationFailure("Wrong message or signature."))?,
         );
 
-        if self.registered_users.borrow().contains_key(&user_id) {
+        if self.registered_users.lock().unwrap().contains_key(&user_id) {
             Ok(user_id)
         } else {
             Err(AuthenticationFailure("User not found."))
@@ -125,8 +124,8 @@ impl Gatekeeper {
         let block_count = self.last_known_block_header.height;
 
         // TODO: For now, new calls to `add_update_user` add subscription_slots to the current count and reset the expiry time
-        let mut borrowed = self.registered_users.borrow_mut();
-        let user_info = match borrowed.get_mut(&user_id) {
+        let mut registered_users = self.registered_users.lock().unwrap();
+        let user_info = match registered_users.get_mut(&user_id) {
             // User already exists, updating the info
             Some(user_info) => {
                 user_info.available_slots = user_info
@@ -150,8 +149,8 @@ impl Gatekeeper {
                     .store_user(user_id, &user_info)
                     .unwrap();
 
-                borrowed.insert(user_id, user_info);
-                borrowed.get_mut(&user_id).unwrap()
+                registered_users.insert(user_id, user_info);
+                registered_users.get_mut(&user_id).unwrap()
             }
         };
 
@@ -170,8 +169,8 @@ impl Gatekeeper {
         appointment: &ExtendedAppointment,
     ) -> Result<u32, NotEnoughSlots> {
         // For updates, the difference between the existing appointment size and the update is computed.
-        let mut borrowed = self.registered_users.borrow_mut();
-        let user_info = borrowed.get_mut(&user_id).unwrap();
+        let mut registered_users = self.registered_users.lock().unwrap();
+        let user_info = registered_users.get_mut(&user_id).unwrap();
         let used_slots = user_info.appointments.get(&uuid).map_or(0, |x| *x);
 
         let required_slots =
@@ -197,7 +196,7 @@ impl Gatekeeper {
         &self,
         user_id: UserId,
     ) -> Result<(bool, u32), AuthenticationFailure<'_>> {
-        self.registered_users.borrow().get(&user_id).map_or(
+        self.registered_users.lock().unwrap().get(&user_id).map_or(
             Err(AuthenticationFailure("User not found.")),
             |user_info| {
                 Ok((
@@ -213,12 +212,13 @@ impl Gatekeeper {
     ///
     /// The data is pulled from the cache if present, otherwise it is computed on the fly.
     pub fn get_outdated_users(&self, block_height: u32) -> HashMap<UserId, Vec<UUID>> {
-        let borrowed = self.outdated_users_cache.borrow();
-        match borrowed.get(&block_height) {
+        let outdated_users_cache = self.outdated_users_cache.lock().unwrap();
+        let registered_users = self.registered_users.lock().unwrap();
+        match outdated_users_cache.get(&block_height) {
             Some(users) => users.clone(),
             None => {
                 let mut users = HashMap::new();
-                for (user_id, user_info) in self.registered_users.borrow().iter() {
+                for (user_id, user_info) in registered_users.iter() {
                     if block_height == user_info.subscription_expiry + self.expiry_delta {
                         users.insert(*user_id, user_info.appointments.keys().cloned().collect());
                     }
@@ -253,25 +253,30 @@ impl Gatekeeper {
 
         if !self
             .outdated_users_cache
-            .borrow()
+            .lock()
+            .unwrap()
             .contains_key(&block_height)
         {
             outdated_users = self.get_outdated_users(block_height);
-            let mut borrowed = self.outdated_users_cache.borrow_mut();
-            borrowed.insert(block_height.clone(), outdated_users.clone());
+            let mut outdated_users_cache = self.outdated_users_cache.lock().unwrap();
+            outdated_users_cache.insert(block_height.clone(), outdated_users.clone());
 
             // Remove the first entry from the cache if it grows beyond the limit size
-            if borrowed.len() > OUTDATED_USERS_CACHE_SIZE_BLOCKS {
+            if outdated_users_cache.len() > OUTDATED_USERS_CACHE_SIZE_BLOCKS {
                 // TODO: This may be simpler using BTreeMaps once first_entry is not nightly anymore
-                let mut keys = borrowed.keys().to_owned().collect::<Vec<&u32>>();
+                let mut keys = outdated_users_cache
+                    .keys()
+                    .to_owned()
+                    .collect::<Vec<&u32>>();
                 keys.sort();
                 let first = keys[0].clone();
 
                 // Remove data from the cache and from the database
                 // TODO: This can be implemented as a batch delete
-                borrowed.remove(&first).map(|users| {
+                let dbm = self.dbm.lock().unwrap();
+                outdated_users_cache.remove(&first).map(|users| {
                     for user_id in users.keys() {
-                        self.dbm.lock().unwrap().remove_user(*user_id);
+                        dbm.remove_user(*user_id);
                     }
                 });
             }
@@ -287,27 +292,23 @@ impl Gatekeeper {
     /// just references to them (the same applies to the database).
     pub fn delete_appointments(&self, appointments: &HashMap<UUID, UserId>) {
         let mut updated_users = HashSet::new();
+        let mut registered_users = self.registered_users.lock().unwrap();
 
         for (uuid, user_id) in appointments {
             // Remove the appointment from the appointment list and update the available slots
-            self.registered_users
-                .borrow_mut()
-                .get_mut(&user_id)
-                .map(|user_info| {
-                    user_info
-                        .appointments
-                        .remove(uuid)
-                        .map(|x| user_info.available_slots += x);
-                    updated_users.insert(user_id);
-                });
+            registered_users.get_mut(&user_id).map(|user_info| {
+                user_info
+                    .appointments
+                    .remove(uuid)
+                    .map(|x| user_info.available_slots += x);
+                updated_users.insert(user_id);
+            });
         }
 
         // Update data in the database
+        let dbm = self.dbm.lock().unwrap();
         for user_id in updated_users {
-            self.dbm.lock().unwrap().update_user(
-                *user_id,
-                self.registered_users.borrow().get(user_id).unwrap(),
-            );
+            dbm.update_user(*user_id, registered_users.get(user_id).unwrap());
         }
     }
 }
@@ -321,8 +322,10 @@ impl chain::Listen for Gatekeeper {
         log::info!("New block received: {}", block.block_hash());
         let outdated_users = self.update_outdated_users_cache(height);
 
+        // Notice users are not deleted from the database at this point, they will be once removed from the cache.
+        let mut registered_users = self.registered_users.lock().unwrap();
         for user_id in outdated_users.keys() {
-            self.registered_users.borrow_mut().remove(user_id);
+            registered_users.remove(user_id);
         }
     }
 
@@ -352,13 +355,11 @@ mod tests {
     const START_HEIGHT: usize = 100;
 
     impl Gatekeeper {
-        pub fn get_registered_users(&self) -> &RefCell<HashMap<UserId, UserInfo>> {
+        pub fn get_registered_users(&self) -> &Mutex<HashMap<UserId, UserInfo>> {
             &self.registered_users
         }
 
-        pub fn get_outdated_users_cache(
-            &self,
-        ) -> &RefCell<HashMap<u32, HashMap<UserId, Vec<UUID>>>> {
+        pub fn get_outdated_users_cache(&self) -> &Mutex<HashMap<u32, HashMap<UserId, Vec<UUID>>>> {
             &self.outdated_users_cache
         }
     }
@@ -442,7 +443,8 @@ mod tests {
         // If the slot count reaches u32::MAX we should receive an error
         gatekeeper
             .registered_users
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .get_mut(&user_id)
             .unwrap()
             .available_slots = u32::MAX;
@@ -479,7 +481,8 @@ mod tests {
         // Now let's add a new appointment
         let slots_before = gatekeeper
             .registered_users
-            .borrow()
+            .lock()
+            .unwrap()
             .get(&user_id)
             .unwrap()
             .available_slots;
@@ -488,7 +491,7 @@ mod tests {
             .add_update_appointment(user_id, uuid, &appointment)
             .unwrap();
 
-        assert!(gatekeeper.registered_users.borrow()[&user_id]
+        assert!(gatekeeper.registered_users.lock().unwrap()[&user_id]
             .appointments
             .contains_key(&uuid));
         assert_eq!(slots_before, available_slots + 1);
@@ -502,7 +505,7 @@ mod tests {
         let mut updated_slot_count = gatekeeper
             .add_update_appointment(user_id, uuid, &appointment)
             .unwrap();
-        assert!(gatekeeper.registered_users.borrow()[&user_id]
+        assert!(gatekeeper.registered_users.lock().unwrap()[&user_id]
             .appointments
             .contains_key(&uuid));
         assert_eq!(updated_slot_count, available_slots);
@@ -515,7 +518,7 @@ mod tests {
         updated_slot_count = gatekeeper
             .add_update_appointment(user_id, uuid, &bigger_appointment)
             .unwrap();
-        assert!(gatekeeper.registered_users.borrow()[&user_id]
+        assert!(gatekeeper.registered_users.lock().unwrap()[&user_id]
             .appointments
             .contains_key(&uuid));
         assert_eq!(updated_slot_count, available_slots - 1);
@@ -526,7 +529,7 @@ mod tests {
         updated_slot_count = gatekeeper
             .add_update_appointment(user_id, uuid, &appointment)
             .unwrap();
-        assert!(gatekeeper.registered_users.borrow()[&user_id]
+        assert!(gatekeeper.registered_users.lock().unwrap()[&user_id]
             .appointments
             .contains_key(&uuid));
         assert_eq!(updated_slot_count, available_slots);
@@ -538,7 +541,7 @@ mod tests {
         updated_slot_count = gatekeeper
             .add_update_appointment(user_id, new_uuid, &appointment)
             .unwrap();
-        assert!(gatekeeper.registered_users.borrow()[&user_id]
+        assert!(gatekeeper.registered_users.lock().unwrap()[&user_id]
             .appointments
             .contains_key(&new_uuid));
         assert_eq!(updated_slot_count, available_slots - 1);
@@ -548,7 +551,8 @@ mod tests {
         // Finally, trying to add an appointment when the user has no enough slots should fail
         gatekeeper
             .registered_users
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .get_mut(&user_id)
             .unwrap()
             .available_slots = 0;
@@ -587,7 +591,8 @@ mod tests {
         let expiry = START_HEIGHT as u32;
         gatekeeper
             .registered_users
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .get_mut(&user_id)
             .unwrap()
             .subscription_expiry = expiry;
@@ -622,11 +627,12 @@ mod tests {
             .unwrap();
 
         // Check that data is not in the cache before querying
-        assert_eq!(gatekeeper.outdated_users_cache.borrow().len(), 0);
+        assert_eq!(gatekeeper.outdated_users_cache.lock().unwrap().len(), 0);
 
         gatekeeper
             .registered_users
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .get_mut(&user_id)
             .unwrap()
             .subscription_expiry = START_HEIGHT as u32;
@@ -639,7 +645,11 @@ mod tests {
         // on the fly
         let target_height = 2;
         assert_eq!(
-            gatekeeper.outdated_users_cache.borrow().get(&target_height),
+            gatekeeper
+                .outdated_users_cache
+                .lock()
+                .unwrap()
+                .get(&target_height),
             None
         );
         assert_eq!(gatekeeper.get_outdated_users(target_height), HashMap::new());
@@ -648,7 +658,8 @@ mod tests {
         hm.insert(user_id, Vec::from([uuid]));
         gatekeeper
             .outdated_users_cache
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .insert(target_height, hm.clone());
         assert_eq!(gatekeeper.get_outdated_users(start_height), hm);
     }
@@ -677,14 +688,16 @@ mod tests {
         // Manually set the user expiry for the test
         gatekeeper
             .registered_users
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .get_mut(&user1_id)
             .unwrap()
             .subscription_expiry = START_HEIGHT as u32;
 
         gatekeeper
             .registered_users
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .get_mut(&user2_id)
             .unwrap()
             .subscription_expiry = START_HEIGHT as u32;
@@ -722,20 +735,21 @@ mod tests {
         gatekeeper.add_update_user(user_id).unwrap();
         gatekeeper
             .registered_users
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .get_mut(&user_id)
             .unwrap()
             .subscription_expiry = start_height - EXPIRY_DELTA - 1;
 
-        assert_eq!(gatekeeper.outdated_users_cache.borrow().len(), 0);
+        assert_eq!(gatekeeper.outdated_users_cache.lock().unwrap().len(), 0);
         gatekeeper.update_outdated_users_cache(start_height - 1);
-        assert_eq!(gatekeeper.outdated_users_cache.borrow().len(), 1);
+        assert_eq!(gatekeeper.outdated_users_cache.lock().unwrap().len(), 1);
 
         // If the cache has room and there's no data to add, an empty entry will be added
         gatekeeper.update_outdated_users_cache(start_height);
-        assert_eq!(gatekeeper.outdated_users_cache.borrow().len(), 2);
+        assert_eq!(gatekeeper.outdated_users_cache.lock().unwrap().len(), 2);
         assert_eq!(
-            gatekeeper.outdated_users_cache.borrow()[&(start_height)],
+            gatekeeper.outdated_users_cache.lock().unwrap()[&(start_height)],
             HashMap::new()
         );
 
@@ -746,12 +760,13 @@ mod tests {
 
         // Check the first key is still there and that the user can still be found in the database
         assert_eq!(
-            gatekeeper.outdated_users_cache.borrow().len(),
+            gatekeeper.outdated_users_cache.lock().unwrap().len(),
             OUTDATED_USERS_CACHE_SIZE_BLOCKS
         );
         assert!(gatekeeper
             .outdated_users_cache
-            .borrow()
+            .lock()
+            .unwrap()
             .contains_key(&(start_height - 1)));
         assert!(matches!(
             dbm.lock().unwrap().load_user(user_id),
@@ -763,12 +778,13 @@ mod tests {
             start_height + OUTDATED_USERS_CACHE_SIZE_BLOCKS as u32 - 1,
         );
         assert_eq!(
-            gatekeeper.outdated_users_cache.borrow().len(),
+            gatekeeper.outdated_users_cache.lock().unwrap().len(),
             OUTDATED_USERS_CACHE_SIZE_BLOCKS
         );
         assert!(!gatekeeper
             .outdated_users_cache
-            .borrow()
+            .lock()
+            .unwrap()
             .contains_key(&(start_height - 1)));
         assert!(matches!(dbm.lock().unwrap().load_user(user_id), Err(..)));
     }
@@ -797,9 +813,9 @@ mod tests {
         }
 
         // Calling the method with unknown data should work but do nothing
-        assert!(gatekeeper.registered_users.borrow().is_empty());
+        assert!(gatekeeper.registered_users.lock().unwrap().is_empty());
         gatekeeper.delete_appointments(&all_appointments);
-        assert!(gatekeeper.registered_users.borrow().is_empty());
+        assert!(gatekeeper.registered_users.lock().unwrap().is_empty());
 
         // If there's matching data in the gatekeeper it should be deleted
         for (uuid, user_id) in to_be_deleted.iter() {
@@ -810,15 +826,15 @@ mod tests {
         }
 
         // Check before deleting
-        assert_eq!(gatekeeper.registered_users.borrow().len(), 5);
+        assert_eq!(gatekeeper.registered_users.lock().unwrap().len(), 5);
         for (uuid, user_id) in to_be_deleted.iter() {
-            assert!(gatekeeper.registered_users.borrow()[user_id]
+            assert!(gatekeeper.registered_users.lock().unwrap()[user_id]
                 .appointments
                 .contains_key(uuid));
 
             // The slot count should be decreased now too (both in memory and in the database)
             assert_ne!(
-                gatekeeper.registered_users.borrow()[user_id].available_slots,
+                gatekeeper.registered_users.lock().unwrap()[user_id].available_slots,
                 gatekeeper.subscription_slots
             );
             assert_ne!(
@@ -833,19 +849,23 @@ mod tests {
             );
         }
         for (_, user_id) in rest.iter() {
-            assert!(!gatekeeper.registered_users.borrow().contains_key(user_id));
+            assert!(!gatekeeper
+                .registered_users
+                .lock()
+                .unwrap()
+                .contains_key(user_id));
         }
 
         // And after
         gatekeeper.delete_appointments(&all_appointments);
         for (uuid, user_id) in to_be_deleted.iter() {
-            assert!(!gatekeeper.registered_users.borrow()[&user_id]
+            assert!(!gatekeeper.registered_users.lock().unwrap()[&user_id]
                 .appointments
                 .contains_key(uuid));
 
             // The slot count is back to default
             assert_eq!(
-                gatekeeper.registered_users.borrow()[&user_id].available_slots,
+                gatekeeper.registered_users.lock().unwrap()[&user_id].available_slots,
                 gatekeeper.subscription_slots
             );
             assert_eq!(
@@ -860,7 +880,11 @@ mod tests {
             );
         }
         for (_, user_id) in rest.iter() {
-            assert!(!gatekeeper.registered_users.borrow().contains_key(user_id));
+            assert!(!gatekeeper
+                .registered_users
+                .lock()
+                .unwrap()
+                .contains_key(user_id));
         }
     }
 
@@ -881,10 +905,10 @@ mod tests {
             last_height += 1;
             gatekeeper.block_connected(chain.blocks.last().unwrap(), last_height);
             if i < OUTDATED_USERS_CACHE_SIZE_BLOCKS {
-                assert_eq!(gatekeeper.outdated_users_cache.borrow().len(), i + 1)
+                assert_eq!(gatekeeper.outdated_users_cache.lock().unwrap().len(), i + 1)
             } else {
                 assert_eq!(
-                    gatekeeper.outdated_users_cache.borrow().len(),
+                    gatekeeper.outdated_users_cache.lock().unwrap().len(),
                     OUTDATED_USERS_CACHE_SIZE_BLOCKS
                 )
             }
@@ -900,7 +924,8 @@ mod tests {
             gatekeeper.add_update_user(user).unwrap();
             gatekeeper
                 .registered_users
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .get_mut(&user)
                 .unwrap()
                 .subscription_expiry = last_height as u32 - EXPIRY_DELTA;
@@ -911,8 +936,14 @@ mod tests {
 
         // Check that users have been added to the cache and removed from registered_users
         for user in vec![user1_id, user2_id, user3_id] {
-            assert!(gatekeeper.outdated_users_cache.borrow()[&last_height].contains_key(&user));
-            assert!(!gatekeeper.registered_users.borrow().contains_key(&user));
+            assert!(
+                gatekeeper.outdated_users_cache.lock().unwrap()[&last_height].contains_key(&user)
+            );
+            assert!(!gatekeeper
+                .registered_users
+                .lock()
+                .unwrap()
+                .contains_key(&user));
 
             // Data is still in the database since the user is in the cache
             assert!(matches!(

--- a/teos/src/lib.rs
+++ b/teos/src/lib.rs
@@ -2,6 +2,11 @@
 //!
 //! A watchtower implementation written in Rust.
 
+pub mod protos {
+    tonic::include_proto!("teos.v1");
+}
+
+pub mod api;
 pub mod bitcoin_cli;
 pub mod carrier;
 pub mod chain_monitor;

--- a/teos/src/responder.rs
+++ b/teos/src/responder.rs
@@ -1,7 +1,6 @@
 //! Logic related to the Responder, the components in charge of making sure breaches get properly punished.
 
 use futures::executor::block_on;
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use std::ops::Deref;
@@ -72,50 +71,50 @@ impl TransactionTracker {
 /// The [Responder] receives data from the [Watcher](crate::watcher::Watcher) in form of a [Breach].
 /// From there, a [TransactionTracker] is created and the penalty transaction is sent to the network via the [Carrier].
 /// The [Transaction] is then monitored to make sure it makes it to a block and it gets [irrevocably resolved](https://github.com/lightning/bolts/blob/master/05-onchain.md#general-nomenclature).
-pub struct Responder<'a> {
+pub struct Responder {
     /// A map holding a summary of every tracker ([TransactionTracker]) hold by the [Responder], identified by [UUID].
     /// The identifiers match those used by the [Watcher](crate::watcher::Watcher).
-    trackers: RefCell<HashMap<UUID, TrackerSummary>>,
+    trackers: Mutex<HashMap<UUID, TrackerSummary>>,
     /// A map between [Txid]s and [UUID]s.
-    tx_tracker_map: RefCell<HashMap<Txid, HashSet<UUID>>>,
+    tx_tracker_map: Mutex<HashMap<Txid, HashSet<UUID>>>,
     /// A collection of transactions yet to get a single confirmation.
     /// Only keeps track of penalty transactions being monitored by the [Responder].
-    unconfirmed_txs: RefCell<HashSet<Txid>>,
+    unconfirmed_txs: Mutex<HashSet<Txid>>,
     /// A collection of [Transaction]s that have missed some confirmation, along with the missed count.
     /// Only keeps track of penalty transactions being monitored by the [Responder].
-    missed_confirmations: RefCell<HashMap<Txid, u8>>,
-    /// A [Carrier] instance. Data is sent to the `bitcoind` trough it.
-    carrier: RefCell<Carrier>,
+    missed_confirmations: Mutex<HashMap<Txid, u8>>,
+    /// A [Carrier] instance. Data is sent to the `bitcoind` through it.
+    carrier: Mutex<Carrier>,
     /// A [Gatekeeper] instance. Data regarding users is requested to it.
-    gatekeeper: &'a Gatekeeper,
+    gatekeeper: Arc<Gatekeeper>,
     /// A [DBM] (database manager) instance. Used to persist tracker data into disk.
     dbm: Arc<Mutex<DBM>>,
     /// The last known block header.
-    last_known_block_header: RefCell<BlockHeaderData>,
+    last_known_block_header: Mutex<BlockHeaderData>,
 }
 
-impl<'a> Responder<'a> {
+impl Responder {
     /// Creates a new [Responder] instance.
     pub fn new(
         carrier: Carrier,
-        gatekeeper: &'a Gatekeeper,
+        gatekeeper: Arc<Gatekeeper>,
         dbm: Arc<Mutex<DBM>>,
         last_known_block_header: ValidatedBlockHeader,
     ) -> Self {
-        let trackers = RefCell::new(HashMap::new());
-        let tx_tracker_map = RefCell::new(HashMap::new());
-        let unconfirmed_txs = RefCell::new(HashSet::new());
-        let missed_confirmations = RefCell::new(HashMap::new());
+        let trackers = Mutex::new(HashMap::new());
+        let tx_tracker_map = Mutex::new(HashMap::new());
+        let unconfirmed_txs = Mutex::new(HashSet::new());
+        let missed_confirmations = Mutex::new(HashMap::new());
 
         Responder {
-            carrier: RefCell::new(carrier),
+            carrier: Mutex::new(carrier),
             trackers,
             tx_tracker_map,
             unconfirmed_txs,
             missed_confirmations,
             dbm,
             gatekeeper,
-            last_known_block_header: RefCell::new(*last_known_block_header.deref()),
+            last_known_block_header: Mutex::new(*last_known_block_header.deref()),
         }
     }
 
@@ -131,7 +130,8 @@ impl<'a> Responder<'a> {
     ) -> DeliveryReceipt {
         let receipt = self
             .carrier
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .send_transaction(&breach.penalty_tx)
             .await;
 
@@ -162,10 +162,11 @@ impl<'a> Responder<'a> {
         let tracker = TransactionTracker::new(breach, user_id);
 
         self.trackers
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .insert(uuid, tracker.get_summary());
 
-        let mut tx_tracker_map = self.tx_tracker_map.borrow_mut();
+        let mut tx_tracker_map = self.tx_tracker_map.lock().unwrap();
         match tx_tracker_map.get_mut(&penalty_txid) {
             Some(map) => {
                 map.insert(uuid);
@@ -175,15 +176,9 @@ impl<'a> Responder<'a> {
             }
         }
 
-        if !self
-            .unconfirmed_txs
-            .borrow()
-            .contains(&tracker.penalty_tx.txid())
-            && confirmations == 0
-        {
-            self.unconfirmed_txs
-                .borrow_mut()
-                .insert(tracker.penalty_tx.txid());
+        let mut unconfirmed_txs = self.unconfirmed_txs.lock().unwrap();
+        if !unconfirmed_txs.contains(&tracker.penalty_tx.txid()) && confirmations == 0 {
+            unconfirmed_txs.insert(tracker.penalty_tx.txid());
         }
 
         self.dbm
@@ -199,27 +194,32 @@ impl<'a> Responder<'a> {
         // Has tracker should return true as long as the given tracker is hold by the Responder.
         // If the tracker is partially kept, the function will log and the return will be false.
         // This may point out that some partial data deletion is happening, which must be fixed.
-        self.trackers.borrow().get(&uuid).map_or(false, |tracker| {
-            self.tx_tracker_map
-                .borrow()
-                .get(&tracker.penalty_txid)
-                .map_or(
-                    {
-                        log::debug!(
+        self.trackers
+            .lock()
+            .unwrap()
+            .get(&uuid)
+            .map_or(false, |tracker| {
+                self.tx_tracker_map
+                    .lock()
+                    .unwrap()
+                    .get(&tracker.penalty_txid)
+                    .map_or(
+                        {
+                            log::debug!(
                             "Partially found Tracker. Some data may have not been properly deleted"
                         );
-                        false
-                    },
-                    |_| true,
-                )
-        })
+                            false
+                        },
+                        |_| true,
+                    )
+            })
     }
 
     /// Gets a tracker from the [Responder] if found. [None] otherwise.
     ///
     /// The [TransactionTracker] is queried to the [DBM].
     pub fn get_tracker(&self, uuid: UUID) -> Option<TransactionTracker> {
-        if self.trackers.borrow().contains_key(&uuid) {
+        if self.trackers.lock().unwrap().contains_key(&uuid) {
             self.dbm.lock().unwrap().load_tracker(uuid).ok()
         } else {
             None
@@ -230,7 +230,7 @@ impl<'a> Responder<'a> {
     /// Otherwise, its unconfirmed count is increased by one.
     fn check_confirmations(&self, txs: &Vec<Transaction>) {
         // A confirmation has been received
-        let mut unconfirmed_txs = self.unconfirmed_txs.borrow_mut();
+        let mut unconfirmed_txs = self.unconfirmed_txs.lock().unwrap();
         for tx in txs.iter() {
             if unconfirmed_txs.remove(&tx.txid()) {
                 log::info!("Confirmation received for transaction: {}", tx.txid());
@@ -238,7 +238,7 @@ impl<'a> Responder<'a> {
         }
 
         // Increase the missing confirmation count for all those transactions pending confirmation that have not been confirmed this block
-        let mut missed_confirmations = self.missed_confirmations.borrow_mut();
+        let mut missed_confirmations = self.missed_confirmations.lock().unwrap();
         for txid in unconfirmed_txs.iter() {
             match missed_confirmations.get_mut(txid) {
                 Some(x) => *x += 1,
@@ -263,10 +263,12 @@ impl<'a> Responder<'a> {
         let mut tx_to_rebroadcast = Vec::new();
         let mut tracker: TransactionTracker;
 
-        for (txid, missed_conf) in self.missed_confirmations.borrow().iter() {
+        let tx_tracker_map = self.tx_tracker_map.lock().unwrap();
+        let dbm = self.dbm.lock().unwrap();
+        for (txid, missed_conf) in self.missed_confirmations.lock().unwrap().iter() {
             if missed_conf >= &CONFIRMATIONS_BEFORE_RETRY {
-                for uuid in self.tx_tracker_map.borrow().get(txid).unwrap() {
-                    tracker = self.dbm.lock().unwrap().load_tracker(*uuid).unwrap();
+                for uuid in tx_tracker_map.get(txid).unwrap() {
+                    tracker = dbm.load_tracker(*uuid).unwrap();
                     tx_to_rebroadcast.push(tracker.penalty_tx)
                 }
             }
@@ -282,11 +284,13 @@ impl<'a> Responder<'a> {
         // DISCUSS: Not using a checked_txs cache for now, check whether it may be necessary
         let mut completed_trackers = HashSet::new();
 
-        for uuid in self.trackers.borrow().keys() {
-            let penalty_txid = self.trackers.borrow()[uuid].penalty_txid;
-            if !self.unconfirmed_txs.borrow().contains(&penalty_txid) {
-                self.carrier
-                    .borrow()
+        let trackers = self.trackers.lock().unwrap();
+        let unconfirmed_txs = self.unconfirmed_txs.lock().unwrap();
+        let carrier = self.carrier.lock().unwrap();
+        for uuid in trackers.keys() {
+            let penalty_txid = trackers[uuid].penalty_txid;
+            if !unconfirmed_txs.contains(&penalty_txid) {
+                carrier
                     .get_confirmations(&penalty_txid)
                     .await
                     .map(|confirmations| {
@@ -304,18 +308,14 @@ impl<'a> Responder<'a> {
     /// from a user who's subscription has been outdated (and therefore will be removed from the tower).
     fn get_outdated_trackers(&self, block_height: u32) -> HashSet<UUID> {
         let mut outdated_trackers = HashSet::new();
-        let trackers: HashSet<UUID> = self.trackers.borrow().keys().cloned().collect();
-
+        let unconfirmed_txs = self.unconfirmed_txs.lock().unwrap();
+        let trackers = self.trackers.lock().unwrap();
         for uuid in self
             .gatekeeper
             .get_outdated_appointments(block_height)
-            .intersection(&trackers)
+            .intersection(&trackers.keys().cloned().collect())
         {
-            if self
-                .unconfirmed_txs
-                .borrow()
-                .contains(&self.trackers.borrow()[&uuid].penalty_txid)
-            {
+            if unconfirmed_txs.contains(&trackers[&uuid].penalty_txid) {
                 outdated_trackers.insert(*uuid);
             }
         }
@@ -328,11 +328,13 @@ impl<'a> Responder<'a> {
     // useful if nodes have wiped the transaction from the mempool for some reasons.
     async fn rebroadcast(&self) -> HashMap<Txid, DeliveryReceipt> {
         let mut receipts = HashMap::new();
+        let mut carrier = self.carrier.lock().unwrap();
 
         for penalty_tx in self.get_txs_to_rebroadcast().into_iter() {
             *self
                 .missed_confirmations
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .get_mut(&penalty_tx.txid())
                 .unwrap() = 0;
 
@@ -341,11 +343,7 @@ impl<'a> Responder<'a> {
                 penalty_tx.txid()
             );
 
-            let receipt = self
-                .carrier
-                .borrow_mut()
-                .send_transaction(&penalty_tx)
-                .await;
+            let receipt = carrier.send_transaction(&penalty_tx).await;
 
             if !receipt.delivered() {
                 // DISCUSS: Check is this can actually happen. Feels like it may if the original tx
@@ -365,8 +363,10 @@ impl<'a> Responder<'a> {
 
     // DISCUSS: Check comment regarding callbacks in watcher.rs
     // TODO: Document once modified given the above comment
-    fn delete_trackers(&self, trackers: HashSet<UUID>, outdated: bool) {
-        for uuid in trackers.iter() {
+    fn delete_trackers(&self, uuids: HashSet<UUID>, outdated: bool) {
+        let mut trackers = self.trackers.lock().unwrap();
+        let mut tx_tracker_map = self.tx_tracker_map.lock().unwrap();
+        for uuid in uuids.iter() {
             if outdated {
                 log::info!("Appointment couldn't be completed. Expiry reached but penalty didn't make it to the chain:  {}", uuid);
             } else {
@@ -376,18 +376,18 @@ impl<'a> Responder<'a> {
                 );
             }
 
-            match self.trackers.borrow_mut().remove(uuid) {
+            match trackers.remove(uuid) {
                 Some(tracker) => {
-                    let mut tracker_map = self.tx_tracker_map.borrow_mut();
-                    let trackers = tracker_map.get_mut(&tracker.penalty_txid).unwrap();
+                    let trackers = tx_tracker_map.get_mut(&tracker.penalty_txid).unwrap();
 
                     // The transaction will only be in the unconfirmed_txs map if the trackers are outdated
                     self.unconfirmed_txs
-                        .borrow_mut()
+                        .lock()
+                        .unwrap()
                         .remove(&tracker.penalty_txid);
 
                     if trackers.len() == 1 {
-                        tracker_map.remove(&tracker.penalty_txid);
+                        tx_tracker_map.remove(&tracker.penalty_txid);
 
                         log::info!(
                             "No more trackers for penalty transaction: {}",
@@ -405,15 +405,12 @@ impl<'a> Responder<'a> {
         }
 
         // Remove both the appointment and tracker matching the given uuids
-        self.dbm
-            .lock()
-            .unwrap()
-            .batch_remove_appointments(&trackers);
+        self.dbm.lock().unwrap().batch_remove_appointments(&uuids);
     }
 }
 
 /// Listen implementation by the [Responder]. Handles monitoring and reorgs.
-impl<'a> Listen for Responder<'a> {
+impl Listen for Responder {
     /// Handles the monitoring process by the [Responder].
     ///
     /// Watching is performed in a per-block basis. A [TransactionTracker] is tracked until:
@@ -426,13 +423,13 @@ impl<'a> Listen for Responder<'a> {
     fn block_connected(&self, block: &bitcoin::Block, height: u32) {
         log::info!("New block received: {}", block.header.block_hash());
 
-        if self.trackers.borrow().len() > 0 {
+        if self.trackers.lock().unwrap().len() > 0 {
             let completed_trackers = block_on(self.get_completed_trackers());
             let outdated_trackers = self.get_outdated_trackers(height);
 
             let trackers_to_delete_gk = completed_trackers
                 .iter()
-                .map(|uuid| (*uuid, self.trackers.borrow()[uuid].user_id))
+                .map(|uuid| (*uuid, self.trackers.lock().unwrap()[uuid].user_id))
                 .collect();
 
             self.check_confirmations(&block.txdata);
@@ -446,14 +443,14 @@ impl<'a> Listen for Responder<'a> {
             block_on(self.rebroadcast());
 
             // Remove all receipts created in this block
-            self.carrier.borrow_mut().clear_receipts();
+            self.carrier.lock().unwrap().clear_receipts();
 
-            if self.trackers.borrow().is_empty() {
+            if self.trackers.lock().unwrap().is_empty() {
                 log::info!("No more pending trackers");
             }
         }
 
-        *self.last_known_block_header.borrow_mut() = BlockHeaderData {
+        *self.last_known_block_header.lock().unwrap() = BlockHeaderData {
             header: block.header,
             height,
             chainwork: block.header.work(),
@@ -488,25 +485,25 @@ mod tests {
         SLOTS, START_HEIGHT,
     };
 
-    impl<'a> Responder<'a> {
-        pub fn get_trackers(&self) -> &RefCell<HashMap<UUID, TrackerSummary>> {
+    impl Responder {
+        pub fn get_trackers(&self) -> &Mutex<HashMap<UUID, TrackerSummary>> {
             &self.trackers
         }
 
-        pub fn get_carrier(&self) -> &RefCell<Carrier> {
+        pub fn get_carrier(&self) -> &Mutex<Carrier> {
             &self.carrier
         }
     }
 
-    fn create_responder<'a>(
+    fn create_responder(
         chain: &mut Blockchain,
-        gatekeeper: &'a Gatekeeper,
+        gatekeeper: Arc<Gatekeeper>,
         dbm: Arc<Mutex<DBM>>,
         query: MockedServerQuery,
-    ) -> Responder<'a> {
+    ) -> Responder {
         let tip = chain.tip();
         let carrier = create_carrier(query);
-        Responder::new(carrier, &gatekeeper, dbm, tip)
+        Responder::new(carrier, gatekeeper, dbm, tip)
     }
 
     #[tokio::test]
@@ -514,7 +511,12 @@ mod tests {
         let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
         let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
-        let responder = create_responder(&mut chain, &gk, dbm.clone(), MockedServerQuery::Regular);
+        let responder = create_responder(
+            &mut chain,
+            Arc::new(gk),
+            dbm.clone(),
+            MockedServerQuery::Regular,
+        );
 
         let user_id = get_random_user_id();
         let (uuid, appointment) = generate_dummy_appointment_with_user(user_id, None);
@@ -526,12 +528,17 @@ mod tests {
         let r = responder.handle_breach(uuid, breach.clone(), user_id).await;
 
         assert!(r.delivered());
-        assert!(responder.trackers.borrow().contains_key(&uuid));
+        assert!(responder.trackers.lock().unwrap().contains_key(&uuid));
         assert!(responder
             .tx_tracker_map
-            .borrow()
+            .lock()
+            .unwrap()
             .contains_key(&penalty_txid));
-        assert!(responder.unconfirmed_txs.borrow().contains(&penalty_txid));
+        assert!(responder
+            .unconfirmed_txs
+            .lock()
+            .unwrap()
+            .contains(&penalty_txid));
     }
 
     #[tokio::test]
@@ -541,7 +548,7 @@ mod tests {
         let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
         let responder = create_responder(
             &mut chain,
-            &gk,
+            Arc::new(gk),
             dbm.clone(),
             MockedServerQuery::Error(rpc_errors::RPC_VERIFY_ERROR as i64),
         );
@@ -554,12 +561,17 @@ mod tests {
         let r = responder.handle_breach(uuid, breach.clone(), user_id).await;
 
         assert!(!r.delivered());
-        assert!(!responder.trackers.borrow().contains_key(&uuid));
+        assert!(!responder.trackers.lock().unwrap().contains_key(&uuid));
         assert!(!responder
             .tx_tracker_map
-            .borrow()
+            .lock()
+            .unwrap()
             .contains_key(&penalty_txid));
-        assert!(!responder.unconfirmed_txs.borrow().contains(&penalty_txid));
+        assert!(!responder
+            .unconfirmed_txs
+            .lock()
+            .unwrap()
+            .contains(&penalty_txid));
     }
 
     #[test]
@@ -567,7 +579,12 @@ mod tests {
         let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
         let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
-        let responder = create_responder(&mut chain, &gk, dbm.clone(), MockedServerQuery::Regular);
+        let responder = create_responder(
+            &mut chain,
+            Arc::new(gk),
+            dbm.clone(),
+            MockedServerQuery::Regular,
+        );
 
         // Add the necessary FKs in the database
         let user_id = get_random_user_id();
@@ -578,15 +595,17 @@ mod tests {
         responder.add_tracker(uuid, breach.clone(), user_id, 0);
 
         // Check that the data has been added to trackers and tom the tx_tracker_map
-        assert!(responder.trackers.borrow().contains_key(&uuid));
+        assert!(responder.trackers.lock().unwrap().contains_key(&uuid));
         assert!(responder
             .tx_tracker_map
-            .borrow()
+            .lock()
+            .unwrap()
             .contains_key(&breach.penalty_tx.txid()));
         // Since the penalty tx was added with no confirmations, check that it has been added to the unconfirmed_transactions map too
         assert!(responder
             .unconfirmed_txs
-            .borrow()
+            .lock()
+            .unwrap()
             .contains(&breach.penalty_tx.txid()));
         // Check that the data is also in the database
         assert_eq!(
@@ -608,18 +627,20 @@ mod tests {
 
         responder.add_tracker(uuid, breach.clone(), user_id, 1);
 
-        assert!(responder.trackers.borrow().contains_key(&uuid));
+        assert!(responder.trackers.lock().unwrap().contains_key(&uuid));
         assert!(responder
             .tx_tracker_map
-            .borrow()
+            .lock()
+            .unwrap()
             .contains_key(&breach.penalty_tx.txid()));
         assert_eq!(
-            responder.tx_tracker_map.borrow()[&breach.penalty_tx.txid()].len(),
+            responder.tx_tracker_map.lock().unwrap()[&breach.penalty_tx.txid()].len(),
             1
         );
         assert!(!responder
             .unconfirmed_txs
-            .borrow()
+            .lock()
+            .unwrap()
             .contains(&breach.penalty_tx.txid()));
         assert_eq!(
             dbm.lock().unwrap().load_tracker(uuid).unwrap(),
@@ -637,13 +658,14 @@ mod tests {
 
         responder.add_tracker(uuid, breach.clone(), user_id, 1);
 
-        assert!(responder.trackers.borrow().contains_key(&uuid));
+        assert!(responder.trackers.lock().unwrap().contains_key(&uuid));
         assert!(responder
             .tx_tracker_map
-            .borrow()
+            .lock()
+            .unwrap()
             .contains_key(&breach.penalty_tx.txid()));
         assert_eq!(
-            responder.tx_tracker_map.borrow()[&breach.penalty_tx.txid()].len(),
+            responder.tx_tracker_map.lock().unwrap()[&breach.penalty_tx.txid()].len(),
             2
         );
         assert_eq!(
@@ -661,7 +683,12 @@ mod tests {
         let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
         let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
-        let responder = create_responder(&mut chain, &gk, dbm.clone(), MockedServerQuery::Regular);
+        let responder = create_responder(
+            &mut chain,
+            Arc::new(gk),
+            dbm.clone(),
+            MockedServerQuery::Regular,
+        );
 
         // Add a new tracker
         let user_id = get_random_user_id();
@@ -684,7 +711,12 @@ mod tests {
         let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
         let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
-        let responder = create_responder(&mut chain, &gk, dbm.clone(), MockedServerQuery::Regular);
+        let responder = create_responder(
+            &mut chain,
+            Arc::new(gk),
+            dbm.clone(),
+            MockedServerQuery::Regular,
+        );
 
         // Store the user and the appointment in the database so we can add the tracker later on (due to FK restrictions)
         let user_id = get_random_user_id();
@@ -710,30 +742,40 @@ mod tests {
         let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
         let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
-        let responder = create_responder(&mut chain, &gk, dbm.clone(), MockedServerQuery::Regular);
+        let responder = create_responder(
+            &mut chain,
+            Arc::new(gk),
+            dbm.clone(),
+            MockedServerQuery::Regular,
+        );
 
         // If a transaction is in the unconfirmed_transactions map it will be removed
         let mut txs = Vec::new();
         for _ in 0..10 {
             let tx = get_random_tx();
             txs.push(tx.clone());
-            responder.unconfirmed_txs.borrow_mut().insert(tx.txid());
+            responder.unconfirmed_txs.lock().unwrap().insert(tx.txid());
         }
 
         responder.check_confirmations(&txs);
 
         for tx in txs.iter() {
-            assert!(!responder.unconfirmed_txs.borrow().contains(&tx.txid()));
+            assert!(!responder
+                .unconfirmed_txs
+                .lock()
+                .unwrap()
+                .contains(&tx.txid()));
             assert!(!responder
                 .missed_confirmations
-                .borrow()
+                .lock()
+                .unwrap()
                 .contains_key(&tx.txid()));
         }
         // All the transactions remaining in the unconfirmed_transactions map are added a missed confirmation
         let mut unconfirmed_txs = Vec::new();
         for (i, tx) in txs.into_iter().enumerate() {
             if i % 2 == 0 {
-                responder.unconfirmed_txs.borrow_mut().insert(tx.txid());
+                responder.unconfirmed_txs.lock().unwrap().insert(tx.txid());
                 unconfirmed_txs.push(tx);
             }
         }
@@ -741,11 +783,16 @@ mod tests {
         for i in 1..10 {
             responder.check_confirmations(&Vec::new());
             for tx in unconfirmed_txs.iter() {
-                assert!(responder.unconfirmed_txs.borrow().contains(&tx.txid()));
+                assert!(responder
+                    .unconfirmed_txs
+                    .lock()
+                    .unwrap()
+                    .contains(&tx.txid()));
                 assert_eq!(
                     responder
                         .missed_confirmations
-                        .borrow()
+                        .lock()
+                        .unwrap()
                         .get(&tx.txid())
                         .unwrap(),
                     &i
@@ -759,7 +806,12 @@ mod tests {
         let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
         let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
-        let responder = create_responder(&mut chain, &gk, dbm.clone(), MockedServerQuery::Regular);
+        let responder = create_responder(
+            &mut chain,
+            Arc::new(gk),
+            dbm.clone(),
+            MockedServerQuery::Regular,
+        );
 
         let user_id = get_random_user_id();
         responder
@@ -789,7 +841,8 @@ mod tests {
             responder.add_tracker(uuid, breach.clone(), user_id, 0);
             responder
                 .missed_confirmations
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .insert(breach.penalty_tx.txid(), i);
         }
 
@@ -806,9 +859,9 @@ mod tests {
         let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
         let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
-        let mut responder = create_responder(
+        let responder = create_responder(
             &mut chain,
-            &gk,
+            Arc::new(gk),
             dbm.clone(),
             MockedServerQuery::Confirmations(1),
         );
@@ -825,11 +878,12 @@ mod tests {
         // Not completed yet
         for i in 1..constants::IRREVOCABLY_RESOLVED + 2 {
             assert_eq!(responder.get_completed_trackers().await, HashSet::new());
-            *responder.carrier.get_mut() = create_carrier(MockedServerQuery::Confirmations(i));
+            *responder.carrier.lock().unwrap() =
+                create_carrier(MockedServerQuery::Confirmations(i));
         }
 
         // Just completed
-        *responder.carrier.get_mut() = create_carrier(MockedServerQuery::Confirmations(
+        *responder.carrier.lock().unwrap() = create_carrier(MockedServerQuery::Confirmations(
             constants::IRREVOCABLY_RESOLVED + 1,
         ));
         assert_eq!(
@@ -842,8 +896,19 @@ mod tests {
     fn test_get_outdated_trackers() {
         let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
-        let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
-        let responder = create_responder(&mut chain, &gk, dbm.clone(), MockedServerQuery::Regular);
+        let gk = Arc::new(Gatekeeper::new(
+            chain.tip(),
+            SLOTS,
+            DURATION,
+            EXPIRY_DELTA,
+            dbm.clone(),
+        ));
+        let responder = create_responder(
+            &mut chain,
+            gk.clone(),
+            dbm.clone(),
+            MockedServerQuery::Regular,
+        );
 
         // Outdated trackers are those whose associated subscription is outdated and have not been confirmed yet (they don't have
         // a single confirmation).
@@ -858,7 +923,8 @@ mod tests {
         let outdated_users: HashMap<UserId, Vec<UUID>> =
             [(user_id, uuids.clone())].iter().cloned().collect();
         gk.get_outdated_users_cache()
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .insert(target_block_height, outdated_users);
 
         // If data is not in the unconfirmed_transaction it won't be returned
@@ -875,13 +941,15 @@ mod tests {
             let tracker = get_random_tracker(user_id);
             responder
                 .trackers
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .insert(uuid, tracker.get_summary());
 
             if i % 2 == 0 {
                 responder
                     .unconfirmed_txs
-                    .borrow_mut()
+                    .lock()
+                    .unwrap()
                     .insert(tracker.penalty_tx.txid());
                 target_uuids.insert(uuid);
             }
@@ -899,7 +967,12 @@ mod tests {
         let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
         let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
-        let responder = create_responder(&mut chain, &gk, dbm.clone(), MockedServerQuery::Regular);
+        let responder = create_responder(
+            &mut chain,
+            Arc::new(gk),
+            dbm.clone(),
+            MockedServerQuery::Regular,
+        );
         let user_id = get_random_user_id();
 
         // Add user to the database
@@ -932,13 +1005,15 @@ mod tests {
             if i % 2 == 0 {
                 responder
                     .missed_confirmations
-                    .borrow_mut()
+                    .lock()
+                    .unwrap()
                     .insert(penalty_txid.clone(), CONFIRMATIONS_BEFORE_RETRY);
                 need_rebroadcast.push(penalty_txid);
             } else {
                 responder
                     .missed_confirmations
-                    .borrow_mut()
+                    .lock()
+                    .unwrap()
                     .insert(penalty_txid.clone(), CONFIRMATIONS_BEFORE_RETRY - 1);
                 dont_need_rebroadcast.push(penalty_txid);
             }
@@ -948,7 +1023,8 @@ mod tests {
             assert_eq!(
                 responder
                     .missed_confirmations
-                    .borrow()
+                    .lock()
+                    .unwrap()
                     .get(&txid)
                     .unwrap()
                     .to_owned(),
@@ -961,7 +1037,8 @@ mod tests {
             assert_eq!(
                 responder
                     .missed_confirmations
-                    .borrow()
+                    .lock()
+                    .unwrap()
                     .get(&txid)
                     .unwrap()
                     .to_owned(),
@@ -975,7 +1052,12 @@ mod tests {
         let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
         let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
-        let responder = create_responder(&mut chain, &gk, dbm.clone(), MockedServerQuery::Regular);
+        let responder = create_responder(
+            &mut chain,
+            Arc::new(gk),
+            dbm.clone(),
+            MockedServerQuery::Regular,
+        );
         let user_id = get_random_user_id();
 
         // Add user to the database
@@ -1012,7 +1094,8 @@ mod tests {
                 let uuid2 = generate_uuid();
                 responder
                     .tx_tracker_map
-                    .borrow_mut()
+                    .lock()
+                    .unwrap()
                     .get_mut(&breach.penalty_tx.txid())
                     .unwrap()
                     .insert(uuid2);
@@ -1034,7 +1117,7 @@ mod tests {
         // the Responder data structures.
         for uuid in all_trackers {
             if target_trackers.contains(&uuid) {
-                assert!(!responder.trackers.borrow().contains_key(&uuid));
+                assert!(!responder.trackers.lock().unwrap().contains_key(&uuid));
                 assert!(matches!(
                     dbm.lock().unwrap().load_tracker(uuid),
                     Err(DBError::NotFound)
@@ -1046,7 +1129,8 @@ mod tests {
                     assert_eq!(
                         responder
                             .tx_tracker_map
-                            .borrow()
+                            .lock()
+                            .unwrap()
                             .get(penalty_txid)
                             .unwrap()
                             .len(),
@@ -1054,13 +1138,18 @@ mod tests {
                     );
                 } else {
                     // Otherwise the whole structure is removed, given it is now empty
-                    assert!(!responder.tx_tracker_map.borrow().contains_key(penalty_txid));
+                    assert!(!responder
+                        .tx_tracker_map
+                        .lock()
+                        .unwrap()
+                        .contains_key(penalty_txid));
                 }
             } else {
-                assert!(responder.trackers.borrow().contains_key(&uuid));
+                assert!(responder.trackers.lock().unwrap().contains_key(&uuid));
                 assert!(responder
                     .tx_tracker_map
-                    .borrow()
+                    .lock()
+                    .unwrap()
                     .contains_key(&uuid_txid_map[&uuid]));
                 assert!(matches!(
                     dbm.lock().unwrap().load_tracker(uuid),
@@ -1074,10 +1163,16 @@ mod tests {
     fn test_block_connected() {
         let mut chain = Blockchain::default().with_height_and_txs(START_HEIGHT, None);
         let dbm = Arc::new(Mutex::new(DBM::in_memory().unwrap()));
-        let gk = Gatekeeper::new(chain.tip(), SLOTS, DURATION, EXPIRY_DELTA, dbm.clone());
+        let gk = Arc::new(Gatekeeper::new(
+            chain.tip(),
+            SLOTS,
+            DURATION,
+            EXPIRY_DELTA,
+            dbm.clone(),
+        ));
         let responder = create_responder(
             &mut chain,
-            &gk,
+            gk.clone(),
             dbm.clone(),
             MockedServerQuery::Confirmations(constants::IRREVOCABLY_RESOLVED + 1),
         );
@@ -1087,19 +1182,20 @@ mod tests {
 
         // If the Responder has no trackers, block_connected will only be used to track the last known block by the Responder.
         assert_eq!(
-            responder.last_known_block_header.borrow().header,
+            responder.last_known_block_header.lock().unwrap().header,
             chain.tip().header
         );
         responder.block_connected(&chain.generate(None), chain.blocks.len() as u32);
         assert_eq!(
-            responder.last_known_block_header.borrow().header,
+            responder.last_known_block_header.lock().unwrap().header,
             chain.tip().header
         );
         // Check the id is also stored in the database
         assert_eq!(
             responder
                 .last_known_block_header
-                .borrow()
+                .lock()
+                .unwrap()
                 .header
                 .block_hash(),
             responder
@@ -1150,7 +1246,8 @@ mod tests {
                 constants::IRREVOCABLY_RESOLVED + 1,
             );
             gk.get_registered_users()
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .get_mut(&user_id)
                 .unwrap()
                 .appointments
@@ -1187,7 +1284,8 @@ mod tests {
         }
 
         gk.get_outdated_users_cache()
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .insert(target_block_height, outdated_users);
 
         // CONFIRMATIONS SETUP
@@ -1232,17 +1330,22 @@ mod tests {
 
         let breach_rebroadcast = get_random_breach_from_locator(appointment.locator());
         responder.add_tracker(uuid, breach_rebroadcast.clone(), standalone_user_id, 0);
-        responder.missed_confirmations.borrow_mut().insert(
+        responder.missed_confirmations.lock().unwrap().insert(
             breach_rebroadcast.penalty_tx.txid(),
             CONFIRMATIONS_BEFORE_RETRY,
         );
 
         // CARRIER CACHE SETUP
         // Add some dummy data in the cache to check that it gets cleared
-        responder.carrier.borrow_mut().get_issued_receipts().insert(
-            get_random_tx().txid(),
-            DeliveryReceipt::new(true, Some(0), None),
-        );
+        responder
+            .carrier
+            .lock()
+            .unwrap()
+            .get_issued_receipts()
+            .insert(
+                get_random_tx().txid(),
+                DeliveryReceipt::new(true, Some(0), None),
+            );
 
         // Connecting a block should trigger all the state transitions
         responder.block_connected(&chain.generate(None), chain.blocks.len() as u32);
@@ -1250,19 +1353,21 @@ mod tests {
         // CARRIER CHECKS
         assert!(responder
             .carrier
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .get_issued_receipts()
             .is_empty());
 
         // COMPLETED TRACKERS CHECKS
         // Data should have been removed
         for (uuid, (user_id, breach)) in completed_trackers {
-            assert!(!responder.trackers.borrow().contains_key(&uuid));
+            assert!(!responder.trackers.lock().unwrap().contains_key(&uuid));
             assert!(!responder
                 .tx_tracker_map
-                .borrow()
+                .lock()
+                .unwrap()
                 .contains_key(&breach.penalty_tx.txid()));
-            assert!(!gk.get_registered_users().borrow()[&user_id]
+            assert!(!gk.get_registered_users().lock().unwrap()[&user_id]
                 .appointments
                 .contains_key(&uuid));
         }
@@ -1270,25 +1375,30 @@ mod tests {
         // OUTDATED TRACKERS CHECKS
         // Data should have been removed
         for uuid in uuids {
-            assert!(!responder.trackers.borrow().contains_key(&uuid));
+            assert!(!responder.trackers.lock().unwrap().contains_key(&uuid));
         }
         for txid in penalties {
-            assert!(!responder.tx_tracker_map.borrow().contains_key(&txid));
-            assert!(!responder.unconfirmed_txs.borrow().contains(&txid));
+            assert!(!responder.tx_tracker_map.lock().unwrap().contains_key(&txid));
+            assert!(!responder.unconfirmed_txs.lock().unwrap().contains(&txid));
         }
 
         // CONFIRMATIONS CHECKS
         // The transaction confirmation count / confirmation missed should have been updated
         for txid in transactions {
             if confirmed_txs.contains(&txid) {
-                assert!(!responder.unconfirmed_txs.borrow().contains(&txid));
-                assert!(!responder.missed_confirmations.borrow().contains_key(&txid));
+                assert!(!responder.unconfirmed_txs.lock().unwrap().contains(&txid));
+                assert!(!responder
+                    .missed_confirmations
+                    .lock()
+                    .unwrap()
+                    .contains_key(&txid));
             } else {
-                assert!(responder.unconfirmed_txs.borrow().contains(&txid));
+                assert!(responder.unconfirmed_txs.lock().unwrap().contains(&txid));
                 assert_eq!(
                     responder
                         .missed_confirmations
-                        .borrow()
+                        .lock()
+                        .unwrap()
                         .get(&txid)
                         .unwrap()
                         .to_owned(),
@@ -1300,7 +1410,7 @@ mod tests {
         // REBROADCAST CHECKS
         // The penalty transaction in breach_rebroadcast should have been rebroadcast
         assert_eq!(
-            responder.missed_confirmations.borrow()[&breach_rebroadcast.penalty_tx.txid()],
+            responder.missed_confirmations.lock().unwrap()[&breach_rebroadcast.penalty_tx.txid()],
             0
         );
     }

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -339,8 +339,9 @@ pub(crate) fn generate_dummy_appointment(dispute_txid: Option<&Txid>) -> Extende
     let tx_bytes = Vec::from_hex(TX_HEX).unwrap();
     let penalty_tx = Transaction::deserialize(&tx_bytes).unwrap();
 
-    let mut locator: [u8; 16] = get_random_bytes(16).try_into().unwrap();
-    locator.copy_from_slice(&dispute_txid[..16]);
+    let mut raw_locator: [u8; 16] = get_random_bytes(16).try_into().unwrap();
+    raw_locator.copy_from_slice(&dispute_txid[..16]);
+    let locator = Locator::deserialize(&raw_locator).unwrap();
 
     let encrypted_blob = encrypt(&penalty_tx, &dispute_txid).unwrap();
     let appointment = Appointment::new(locator, encrypted_blob, 21);

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -9,7 +9,7 @@
 
 use rand::Rng;
 use std::convert::TryInto;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use jsonrpc_http_server::jsonrpc_core::error::ErrorCode as JsonRpcErrorCode;
@@ -30,7 +30,9 @@ use bitcoin::network::constants::Network;
 use bitcoin::util::hash::bitcoin_merkle_root;
 use bitcoin::util::psbt::serialize::Deserialize;
 use bitcoin::util::uint::Uint256;
-use lightning_block_sync::poll::{Validate, ValidatedBlockHeader};
+use lightning_block_sync::poll::{
+    ChainPoller, Poll, Validate, ValidatedBlock, ValidatedBlockHeader,
+};
 use lightning_block_sync::{
     AsyncBlockSourceResult, BlockHeaderData, BlockSource, BlockSourceError, UnboundedCache,
 };
@@ -42,9 +44,12 @@ use teos_common::UserId;
 use crate::carrier::Carrier;
 use crate::dbm::DBM;
 use crate::extended_appointment::{ExtendedAppointment, UUID};
+use crate::gatekeeper::Gatekeeper;
 use crate::gatekeeper::UserInfo;
+use crate::responder::Responder;
 use crate::responder::TransactionTracker;
 use crate::watcher::Breach;
+use crate::watcher::Watcher;
 
 pub static TX_HEX: &str =  "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff54038e830a1b4d696e656420627920416e74506f6f6c373432c2005b005e7a0ae3fabe6d6d7841cd582ead8ea5dd8e3de1173cae6fcd2a53c7362ebb7fb6f815604fe07cbe0200000000000000ac0e060005f90000ffffffff04d9476026000000001976a91411dbe48cc6b617f9c6adaf4d9ed5f625b1c7cb5988ac0000000000000000266a24aa21a9ed7248c6efddd8d99bfddd7f499f0b915bffa8253003cc934df1ff14a81301e2340000000000000000266a24b9e11b6d7054937e13f39529d6ad7e685e9dd4efa426f247d5f5a5bed58cdddb2d0fa60100000000000000002b6a2952534b424c4f434b3a054a68aa5368740e8b3e3c67bce45619c2cfd07d4d4f0936a5612d2d0034fa0a0120000000000000000000000000000000000000000000000000000000000000000000000000";
 pub static TXID_HEX: &str = "338bda693c4a26e0d41a01f7f2887aaf48bf0bdf93e6415c9110b29349349d3e";
@@ -387,6 +392,24 @@ pub fn store_appointment_and_fks_to_db(dbm: &DBM, uuid: UUID, appointment: &Exte
     dbm.store_appointment(uuid, &appointment).unwrap();
 }
 
+pub(crate) async fn get_last_n_blocks(chain: &mut Blockchain, n: usize) -> Vec<ValidatedBlock> {
+    let tip = chain.tip();
+    let mut poller = ChainPoller::new(chain, Network::Bitcoin);
+
+    let mut last_n_blocks = Vec::new();
+    let mut last_known_block = tip;
+    for _ in 0..n {
+        let block = poller.fetch_block(&last_known_block).await.unwrap();
+        last_known_block = poller
+            .look_up_previous_header(&last_known_block)
+            .await
+            .unwrap();
+        last_n_blocks.push(block);
+    }
+
+    last_n_blocks
+}
+
 pub enum MockedServerQuery {
     Regular,
     Confirmations(u32),
@@ -407,6 +430,42 @@ pub fn create_carrier(query: MockedServerQuery) -> Carrier {
     Carrier::new(bitcoin_cli)
 }
 
+pub fn create_responder(
+    tip: ValidatedBlockHeader,
+    gatekeeper: Arc<Gatekeeper>,
+    dbm: Arc<Mutex<DBM>>,
+    server_url: String,
+) -> Responder {
+    let bitcoin_cli = Arc::new(BitcoindClient::new(server_url, Auth::None).unwrap());
+    let carrier = Carrier::new(bitcoin_cli);
+
+    Responder::new(carrier, gatekeeper, dbm, tip)
+}
+
+pub(crate) async fn create_watcher(
+    chain: &mut Blockchain,
+    responder: Arc<Responder>,
+    gatekeeper: Arc<Gatekeeper>,
+    bitcoind_mock: BitcoindMock,
+    dbm: Arc<Mutex<DBM>>,
+) -> Watcher {
+    let tip = chain.tip();
+    let last_n_blocks = get_last_n_blocks(chain, 6).await;
+
+    start_server(bitcoind_mock);
+    let (tower_sk, tower_pk) = get_random_keypair();
+    let tower_id = UserId(tower_pk);
+    Watcher::new(
+        gatekeeper,
+        responder,
+        last_n_blocks,
+        tip,
+        tower_sk,
+        tower_id,
+        dbm,
+    )
+    .await
+}
 pub struct BitcoindMock {
     pub url: String,
     pub server: Server,


### PR DESCRIPTION
Adds the `InternalAPI`, a gRPC server that interfaces with the tower internals.

The `InternalAPI` is the only endpoint to send data to the tower, it has two main interfaces, the public and the private.

The public interface is reachable by users via any tower client, and contains the functionality required to register and send/retrieve appointments to/from the tower.

The private interface is reachable by the tower admin via the gRPC client (teos-cli) and contains functionality to manage and interact with the tower from an admin perspective.

The major change w.r.t the existing codebase is that the main components are not `Arc/Mutex` instead of `Rc/RefCell` given the gRPC server introduces a new thread, so components need to be safely shared between threads.

Some minor changes include how `Appointments` are created.  Locators are now passed build as `Locator` structs instead of raw data. This minimizes the boilerplate when encoding / decoding appointments by the gRPC server but also by the `DBM`.