### PR TITLE
Adds teos-cli and reformats conf.rs

### DIFF
--- a/teos/src/cli.rs
+++ b/teos/src/cli.rs
@@ -1,0 +1,75 @@
+use std::fs;
+use std::str::FromStr;
+use structopt::StructOpt;
+use tonic::Request;
+
+use rusty_teos::cli_config::{Command, Config, Opt};
+use rusty_teos::config;
+use rusty_teos::protos as msgs;
+use rusty_teos::protos::private_tower_services_client::PrivateTowerServicesClient;
+use teos_common::UserId;
+
+#[tokio::main]
+async fn main() {
+    let opt = Opt::from_args();
+    let path = config::data_dir_absolute_path(opt.data_dir.clone());
+
+    // Create data dir if it does not exist
+    fs::create_dir_all(&path).unwrap_or_else(|e| {
+        eprint!("Cannot create data dir: {:?}\n", e);
+        std::process::exit(1);
+    });
+
+    let command = opt.command.clone();
+
+    // Load conf (from file or defaults) and patch it with the command line parameters received (if any)
+    let mut conf = config::from_file::<Config>(path.join("teos.toml"));
+    conf.patch_with_options(opt);
+
+    // Create gRPC client and send request
+    let mut client =
+        PrivateTowerServicesClient::connect(format!("http://{}:{}", conf.rpc_bind, conf.rpc_port))
+            .await
+            .unwrap_or_else(|e| {
+                eprint!("Cannot connect to the tower. Connection refused\n");
+                if conf.debug {
+                    eprint!("{:?}\n", e);
+                }
+                std::process::exit(1);
+            });
+
+    match command {
+        Command::GetAllAppointments => {
+            let appointments = client.get_all_appointments(Request::new(())).await.unwrap();
+            println!("{}", appointments.into_inner());
+        }
+        Command::GetTowerInfo => {
+            let info = client.get_tower_info(Request::new(())).await.unwrap();
+            println!("{}", info.into_inner())
+        }
+        Command::GetUsers => {
+            let users = client.get_users(Request::new(())).await.unwrap();
+            println!("{}", users.into_inner());
+        }
+        Command::GetUser(data) => {
+            match UserId::from_str(&data.user_id) {
+                Ok(user_id) => {
+                    match client
+                        .get_user(Request::new(msgs::GetUserRequest {
+                            user_id: user_id.serialize(),
+                        }))
+                        .await
+                    {
+                        Ok(response) => println!("{}", response.into_inner()),
+                        Err(status) => println!("{}", status.message()),
+                    }
+                }
+                Err(e) => println!("{}", e),
+            };
+        }
+        Command::Stop => {
+            println!("Shutting down tower");
+            client.stop(Request::new(())).await.unwrap();
+        }
+    };
+}

--- a/teos/src/cli_config.rs
+++ b/teos/src/cli_config.rs
@@ -1,0 +1,100 @@
+//! Logic related to the tower CLI configuration and command line parameter parsing.
+
+use serde::Deserialize;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt, Clone)]
+#[structopt(rename_all = "snake_case")]
+pub enum Command {
+    /// Gets information about all appointments stored in the tower
+    GetAllAppointments,
+    /// Gets generic information about the tower, like tower id and aggregate data on users and appointments
+    GetTowerInfo,
+    /// Gets an array with the user ids of all the users registered to the tower
+    GetUsers,
+    /// Gets information about a specific user
+    GetUser(GetUserData),
+    /// Requests a graceful shutdown of the tower
+    Stop,
+}
+
+#[derive(Debug, StructOpt, Clone)]
+#[structopt(rename_all = "lowercase")]
+pub struct GetUserData {
+    /// The user identifier (33-byte compressed public key).
+    pub user_id: String,
+}
+
+/// Holds all the command line options and commands.
+#[derive(StructOpt, Debug)]
+#[structopt(rename_all = "lowercase")]
+#[structopt(
+    version = "0.0.1",
+    about = "The Eye of Satoshi - CLI",
+    name = "teos-cli"
+)]
+pub struct Opt {
+    /// Address teos RPC server is bind to [default: localhost]
+    #[structopt(long)]
+    pub rpc_bind: Option<String>,
+
+    /// Port teos RPC server is bind to [default: 8814]
+    #[structopt(long)]
+    pub rpc_port: Option<u16>,
+
+    /// Specify data directory
+    #[structopt(long, default_value = "~/.teos")]
+    pub data_dir: String,
+
+    /// Runs teos-cli in debug mode [default: false]
+    #[structopt(long)]
+    pub debug: bool,
+
+    /// Command
+    #[structopt(subcommand)]
+    pub command: Command,
+}
+
+/// Holds all configuration options.
+///
+/// The overwrite policy goes, from less to more:
+/// - Defaults
+/// - Configuration file
+/// - Command line options
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(default)]
+pub struct Config {
+    pub rpc_bind: String,
+    pub rpc_port: u16,
+    pub debug: bool,
+}
+
+impl Config {
+    /// Patches the configuration options with the command line options.
+    pub fn patch_with_options(&mut self, options: Opt) {
+        if options.rpc_bind.is_some() {
+            self.rpc_bind = options.rpc_bind.unwrap();
+        }
+        if options.rpc_port.is_some() {
+            self.rpc_port = options.rpc_port.unwrap();
+        }
+
+        self.debug = self.debug | options.debug;
+    }
+}
+
+impl Default for Config {
+    /// Sets the tower [Config] defaults.
+    ///
+    /// Notice the defaults are not enough, and the tower will refuse to run on them.
+    /// For instance, the defaults do set the `bitcoind` `rpu_user` and `rpc_password`
+    /// to empty strings so the user is forced the set them (and most importantly so the
+    /// user does not use any values provided here).
+    fn default() -> Self {
+        Self {
+            rpc_bind: "localhost".into(),
+            rpc_port: 8814,
+            debug: false,
+        }
+    }
+}

--- a/teos/src/lib.rs
+++ b/teos/src/lib.rs
@@ -5,17 +5,19 @@
 pub mod protos {
     tonic::include_proto!("teos.v1");
 }
-
 pub mod api;
 pub mod bitcoin_cli;
 pub mod carrier;
 pub mod chain_monitor;
+pub mod cli_config;
 pub mod config;
 pub mod dbm;
 #[doc(hidden)]
 mod errors;
 mod extended_appointment;
 pub mod gatekeeper;
+#[doc(hidden)]
+mod proto_fmt;
 pub mod responder;
 #[doc(hidden)]
 mod rpc_errors;

--- a/teos/src/proto_fmt.rs
+++ b/teos/src/proto_fmt.rs
@@ -1,0 +1,77 @@
+//! Formatting logic for proto messages.
+
+use crate::protos;
+use hex;
+
+impl std::fmt::Display for protos::GetAllAppointmentsResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.appointments.is_empty() {
+            write!(f, "[]")?;
+        } else {
+            write!(f, "[\n")?;
+            for appointment in self.appointments.iter() {
+                write!(f, "\t{},\n", appointment)?;
+            }
+            write!(f, "\n]")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for protos::AppointmentData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.appointment_data {
+            Some(ref data) => match data {
+                protos::appointment_data::AppointmentData::Appointment(a) => {
+                    write!(f,
+                        "appointment: {{\n\t\tlocator: {},\n\t\tencrypted_blob: {},\n\t\tto_self_delay: {}\n\t}}", 
+                        hex::encode(a.locator.clone()), hex::encode(a.encrypted_blob.clone()), a.to_self_delay)
+                }
+                protos::appointment_data::AppointmentData::Tracker(t) => {
+                    write!(f,
+                        "tracker: {{\n\t\tlocator: {},\n\t\tdispute_txid: {},\n\t\tpenalty_txid: {},\n\t\tpenalty_rawtx: {}\n\t}}", 
+                        hex::encode(t.locator.clone()), hex::encode(t.dispute_txid.clone()), hex::encode(t.penalty_txid.clone()), hex::encode(t.penalty_rawtx.clone()))
+                }
+            },
+            None => write!(f, ""),
+        }
+    }
+}
+
+impl std::fmt::Display for protos::GetTowerInfoResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{\n\ttower_id: {},\n\tn_registered_users: {},\n\tn_watcher_appointments: {},\n\tn_responder_trackers: {},\n}}",
+            hex::encode(&self.tower_id),
+            self.n_registered_users,
+            self.n_watcher_appointments,
+            self.n_responder_trackers
+        )
+    }
+}
+
+impl std::fmt::Display for protos::GetUsersResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.user_ids.is_empty() {
+            write!(f, "[]")?;
+        } else {
+            write!(f, "[\n")?;
+            for user_id in self.user_ids.iter() {
+                write!(f, "\t{},\n", hex::encode(user_id))?;
+            }
+            write!(f, "]")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for protos::GetUserResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{\n\tavailable_slots: {},\n\tsubscription_expiry: {},\n\tappointments: {:#?},\n}}",
+            self.available_slots, self.subscription_expiry, self.appointments,
+        )
+    }
+}


### PR DESCRIPTION
Adds teos-cli alongside it's own configuration parsing. `config.rs` has been reformatted so `cli-config.rs` can reuse as much functionality as possible.

`main.rs` now runs two different gRPC servers, a public one (using `rpc_bind` and `rpc_port`) where `teos-cli connects` to and an internal one (using `internal_api_bind` and `internal_api_port`) where the public APIs will connect to.