### PR TITLE
Adds public API (HTTP)

### DIFF
--- a/teos-common/Cargo.toml
+++ b/teos-common/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uuid = { version = "0.8", features = ["serde", "v4"] }
 hex = "0.4.3"
 
 rand = "0.8.4"

--- a/teos-common/src/errors.rs
+++ b/teos-common/src/errors.rs
@@ -1,0 +1,20 @@
+/// General errors [1, 32]
+pub const MISSING_FIELD: u8 = 1;
+pub const EMPTY_FIELD: u8 = 2;
+pub const WRONG_FIELD_TYPE: u8 = 3;
+pub const WRONG_FIELD_SIZE: u8 = 4;
+pub const WRONG_FIELD_FORMAT: u8 = 5;
+pub const INVALID_REQUEST_FORMAT: u8 = 6;
+pub const INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR: u8 = 7;
+
+/// Appointment errors [33, 64]
+pub const APPOINTMENT_FIELD_TOO_SMALL: u8 = 33;
+pub const APPOINTMENT_FIELD_TOO_BIG: u8 = 34;
+pub const APPOINTMENT_WRONG_FIELD: u8 = 35;
+pub const APPOINTMENT_ALREADY_TRIGGERED: u8 = 36;
+
+/// Registration errors [65, 96]
+pub const REGISTRATION_RESOURCE_EXHAUSTED: u8 = 65;
+
+/// UNHANDLED
+pub const UNEXPECTED_ERROR: u8 = 255;

--- a/teos-common/src/errors.rs
+++ b/teos-common/src/errors.rs
@@ -10,8 +10,7 @@ pub const INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR: u8 = 7;
 /// Appointment errors [33, 64]
 pub const APPOINTMENT_FIELD_TOO_SMALL: u8 = 33;
 pub const APPOINTMENT_FIELD_TOO_BIG: u8 = 34;
-pub const APPOINTMENT_WRONG_FIELD: u8 = 35;
-pub const APPOINTMENT_ALREADY_TRIGGERED: u8 = 36;
+pub const APPOINTMENT_ALREADY_TRIGGERED: u8 = 35;
 
 /// Registration errors [65, 96]
 pub const REGISTRATION_RESOURCE_EXHAUSTED: u8 = 65;

--- a/teos-common/src/lib.rs
+++ b/teos-common/src/lib.rs
@@ -5,11 +5,14 @@
 pub mod appointment;
 pub mod constants;
 pub mod cryptography;
+pub mod errors;
 pub mod receipts;
 
 use std::fmt;
 
 use bitcoin::secp256k1::{Error, PublicKey};
+
+pub const USER_ID_LEN: usize = 33;
 
 /// User identifier. A wrapper around a [PublicKey].
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]

--- a/teos/Cargo.toml
+++ b/teos/Cargo.toml
@@ -47,3 +47,4 @@ tonic-build = "0.6"
 rand = "0.8.4"
 chunked_transfer = "1.4"
 jsonrpc-http-server = "17.1.0"
+tokio-stream = {version = "0.1.5", features = ["net"]}

--- a/teos/Cargo.toml
+++ b/teos/Cargo.toml
@@ -17,7 +17,7 @@ home = "0.5.3"
 toml = "0.5"
 structopt = "0.3"
 serde = "1.0.130"
-hex = "0.4.3"
+hex = {version = "0.4.3", features = ["serde"] }
 base64 = "0.13.0"
 futures = "0.3"
 log = "0.4"
@@ -29,6 +29,8 @@ serde_json = "1.0"
 rusqlite = {version = "0.26.0", features = ["bundled", "limits"]}
 tokio = { version = "1.5", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
 triggered = "0.1.2"
+warp = "0.3.2"
+
 
 bitcoin = "0.27"
 lightning-block-sync = {version = "0.0.103", git = "https://github.com/rust-bitcoin/rust-lightning", branch = "main", features = [ "rpc-client" ] }

--- a/teos/build.rs
+++ b/teos/build.rs
@@ -1,12 +1,29 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure().compile(
-        &[
-            "proto/teos/appointment.proto",
-            "proto/teos/tower_services.proto",
-            "proto/teos/user.proto",
-        ],
-        &["proto/teos"],
-    )?;
+    tonic_build::configure()
+        .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
+        .type_attribute("AppointmentData.appointment_data", "#[serde(untagged)]")
+        .field_attribute("AppointmentData.appointment_data", "#[serde(flatten)]")
+        .field_attribute("appointment_data", "#[serde(rename = \"appointment\")]")
+        .field_attribute("user_id", "#[serde(with = \"hex::serde\")]")
+        .field_attribute("locator", "#[serde(with = \"hex::serde\")]")
+        .field_attribute("encrypted_blob", "#[serde(with = \"hex::serde\")]")
+        .field_attribute("tx", "#[serde(with = \"hex::serde\")]")
+        .field_attribute(
+            "locators",
+            "#[serde(serialize_with = \"crate::api::http::serialize_locators\")]",
+        )
+        .field_attribute(
+            "GetAppointmentResponse.status",
+            "#[serde(with = \"crate::api::serde_status\")]",
+        )
+        .compile(
+            &[
+                "proto/teos/appointment.proto",
+                "proto/teos/tower_services.proto",
+                "proto/teos/user.proto",
+            ],
+            &["proto/teos"],
+        )?;
 
     Ok(())
 }

--- a/teos/src/api/http.rs
+++ b/teos/src/api/http.rs
@@ -1,105 +1,23 @@
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
 use std::convert::Infallible;
 use std::error::Error;
 use std::net::SocketAddr;
 use tonic::{transport::Channel, Code};
 use triggered::Listener;
-use warp::{http::StatusCode, reply, Filter, Rejection, Reply};
+use warp::{http::StatusCode, reject, reply, Filter, Rejection, Reply};
 
-use teos_common::appointment::{AppointmentStatus, LOCATOR_LEN};
-use teos_common::errors;
-use teos_common::USER_ID_LEN;
+use teos_common::appointment::LOCATOR_LEN;
+use teos_common::{errors, USER_ID_LEN};
 
 use crate::protos as msgs;
 use crate::protos::public_tower_services_client::PublicTowerServicesClient;
 
-// REQUEST TYPES
-#[derive(Serialize, Deserialize, Debug)]
-struct RegisterData {
-    #[serde(with = "hex::serde")]
-    user_id: Vec<u8>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct AddAppointmentData {
-    appointment: Appointment,
-    signature: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Appointment {
-    #[serde(with = "hex::serde")]
-    locator: Vec<u8>,
-    #[serde(with = "hex::serde")]
-    encrypted_blob: Vec<u8>,
-    to_self_delay: u32,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct GetAppointmentData {
-    #[serde(with = "hex::serde")]
-    locator: Vec<u8>,
-    signature: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct GetSubscriptionInfoData {
-    signature: String,
-}
-
-// RESPONSE TYPES
-#[derive(Serialize, Deserialize, Debug)]
-struct RegisterResponse {
-    #[serde(with = "hex::serde")]
-    user_id: Vec<u8>,
-    available_slots: u32,
-    subscription_expiry: u32,
-    subscription_signature: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct AddAppointmentResponse {
-    #[serde(with = "hex::serde")]
-    locator: Vec<u8>,
-    start_block: u32,
-    signature: String,
-    available_slots: u32,
-    subscription_expiry: u32,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct GetAppointmentResponse {
-    #[serde(flatten)]
-    appointment: AppointmentOrTracker,
-    status: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-enum AppointmentOrTracker {
-    #[serde(rename = "appointment")]
-    Appointment(Appointment),
-    #[serde(rename = "appointment")]
-    Tracker(Tracker),
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Tracker {
-    #[serde(with = "hex::serde")]
-    locator: Vec<u8>,
-    #[serde(with = "hex::serde")]
-    dispute_txid: Vec<u8>,
-    #[serde(with = "hex::serde")]
-    penalty_txid: Vec<u8>,
-    #[serde(with = "hex::serde")]
-    penalty_rawtx: Vec<u8>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct SubscriptionInfoResponse {
-    available_slots: u32,
-    subscription_expiry: u32,
-    locators: Vec<String>,
-}
+// TODO: Limit the body length for /add_appointment should not be needed, since slots are consumed proportionally to it.
+// Setting a limit for now just to prevent spam to some extend, but this is likely to be lifted.
+const REGISTER_BODY_LEN: u64 = 87;
+const ADD_APPOINTMENT_BODY_LEN: u64 = 2048;
+const GET_APPOINTMENT_BODY_LEN: u64 = 178;
+const GET_SUBSCRIPTION_INFO_BODY_LEN: u64 = 127;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub(crate) struct ApiError {
@@ -107,10 +25,47 @@ pub(crate) struct ApiError {
     error_code: u8,
 }
 
+impl reject::Reject for ApiError {}
+
 impl ApiError {
     fn new(error: String, error_code: u8) -> Self {
         ApiError { error, error_code }
     }
+
+    fn missing_field(field_name: &str) -> Rejection {
+        reject::custom(Self::new(
+            format!("missing field `{}`", field_name),
+            errors::MISSING_FIELD,
+        ))
+    }
+
+    fn empty_field(field_name: &str) -> Rejection {
+        reject::custom(Self::new(
+            format!("`{}` field is empty", field_name),
+            errors::EMPTY_FIELD,
+        ))
+    }
+
+    fn wrong_field_length(field_name: &str, field_size: usize, expected_size: usize) -> Rejection {
+        reject::custom(Self::new(
+            format!(
+                "Wrong `{}` field size. Expected {}, received {}",
+                field_name, expected_size, field_size
+            ),
+            errors::WRONG_FIELD_SIZE,
+        ))
+    }
+}
+
+pub fn serialize_locators<S>(locators: &Vec<Vec<u8>>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut seq = s.serialize_seq(Some(locators.len()))?;
+    for element in locators.iter() {
+        seq.serialize_element(&hex::encode(element))?;
+    }
+    seq.end()
 }
 
 fn with_grpc(
@@ -119,63 +74,24 @@ fn with_grpc(
     warp::any().map(move || grpc_endpoint.clone())
 }
 
-fn empty_field(field_name: &str) -> reply::WithStatus<reply::Json> {
-    reply::with_status(
-        reply::json(&ApiError::new(
-            format!("{} field is empty", field_name),
-            errors::EMPTY_FIELD,
-        )),
-        StatusCode::BAD_REQUEST,
-    )
-}
-
-fn wrong_field_length(
-    field_name: &str,
-    field_size: usize,
-    expected_size: usize,
-) -> reply::WithStatus<reply::Json> {
-    reply::with_status(
-        warp::reply::json(&ApiError::new(
-            format!(
-                "Wrong {} field size. Expected {}, received {}",
-                field_name, expected_size, field_size
-            ),
-            errors::WRONG_FIELD_SIZE,
-        )),
-        StatusCode::BAD_REQUEST,
-    )
-}
-
 async fn register(
-    data: RegisterData,
+    req: msgs::RegisterRequest,
     mut grpc_conn: PublicTowerServicesClient<Channel>,
 ) -> std::result::Result<impl Reply, Rejection> {
-    let user_id = data.user_id;
+    let user_id = req.user_id.clone();
     if user_id.is_empty() {
-        return Ok(empty_field("user_id"));
+        return Err(ApiError::empty_field("user_id"));
     }
     if user_id.len() != USER_ID_LEN {
-        return Ok(wrong_field_length("user_id", user_id.len(), USER_ID_LEN));
+        return Err(ApiError::wrong_field_length(
+            "user_id",
+            user_id.len(),
+            USER_ID_LEN,
+        ));
     }
 
-    let (body, status) = match grpc_conn
-        .register(msgs::RegisterRequest {
-            user_id: user_id.to_vec(),
-        })
-        .await
-    {
-        Ok(r) => {
-            let body = r.into_inner();
-            (
-                warp::reply::json(&RegisterResponse {
-                    user_id: body.user_id,
-                    available_slots: body.available_slots,
-                    subscription_expiry: body.subscription_expiry,
-                    subscription_signature: body.subscription_signature,
-                }),
-                StatusCode::OK,
-            )
-        }
+    let (body, status) = match grpc_conn.register(req).await {
+        Ok(r) => (reply::json(&r.into_inner()), StatusCode::OK),
         Err(s) => {
             let error_code = match s.code() {
                 Code::InvalidArgument => errors::WRONG_FIELD_FORMAT,
@@ -186,7 +102,7 @@ async fn register(
                 }
             };
             (
-                warp::reply::json(&ApiError::new(s.message().into(), error_code)),
+                reply::json(&ApiError::new(s.message().into(), error_code)),
                 StatusCode::BAD_REQUEST,
             )
         }
@@ -196,44 +112,29 @@ async fn register(
 }
 
 async fn add_appointment(
-    data: AddAppointmentData,
+    req: msgs::AddAppointmentRequest,
     mut grpc_conn: PublicTowerServicesClient<Channel>,
 ) -> std::result::Result<impl Reply, Rejection> {
-    let locator = data.appointment.locator;
-    if locator.is_empty() {
-        return Ok(empty_field("locator"));
+    if let Some(a) = &req.appointment {
+        if a.locator.is_empty() {
+            return Err(ApiError::empty_field("locator"));
+        }
+        if a.locator.len() != LOCATOR_LEN {
+            return Err(ApiError::wrong_field_length(
+                "locator",
+                a.locator.len(),
+                LOCATOR_LEN,
+            ));
+        }
+    } else {
+        return Err(ApiError::missing_field("appointment"));
     }
-    if locator.len() != LOCATOR_LEN {
-        return Ok(wrong_field_length("locator", locator.len(), LOCATOR_LEN));
-    }
-    if data.signature.is_empty() {
-        return Ok(empty_field("signature"));
+    if req.signature.is_empty() {
+        return Err(ApiError::empty_field("signature"));
     }
 
-    let (body, status) = match grpc_conn
-        .add_appointment(msgs::AddAppointmentRequest {
-            appointment: Some(msgs::Appointment {
-                locator: locator.to_vec(),
-                encrypted_blob: data.appointment.encrypted_blob,
-                to_self_delay: data.appointment.to_self_delay,
-            }),
-            signature: data.signature,
-        })
-        .await
-    {
-        Ok(r) => {
-            let body = r.into_inner();
-            (
-                warp::reply::json(&AddAppointmentResponse {
-                    locator: body.locator,
-                    start_block: body.start_block,
-                    signature: body.signature,
-                    available_slots: body.available_slots,
-                    subscription_expiry: body.subscription_expiry,
-                }),
-                StatusCode::OK,
-            )
-        }
+    let (body, status) = match grpc_conn.add_appointment(req).await {
+        Ok(r) => (reply::json(&r.into_inner()), StatusCode::OK),
         Err(s) => {
             let error_code = match s.code() {
                 Code::Unauthenticated => errors::INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR,
@@ -244,7 +145,7 @@ async fn add_appointment(
                 }
             };
             (
-                warp::reply::json(&ApiError::new(s.message().into(), error_code)),
+                reply::json(&ApiError::new(s.message().into(), error_code)),
                 StatusCode::BAD_REQUEST,
             )
         }
@@ -254,57 +155,25 @@ async fn add_appointment(
 }
 
 async fn get_appointment(
-    data: GetAppointmentData,
+    req: msgs::GetAppointmentRequest,
     mut grpc_conn: PublicTowerServicesClient<Channel>,
 ) -> std::result::Result<impl Reply, Rejection> {
-    let locator = data.locator;
-    if locator.is_empty() {
-        return Ok(empty_field("locator"));
+    if req.locator.is_empty() {
+        return Err(ApiError::empty_field("locator"));
     }
-    if locator.len() != LOCATOR_LEN {
-        return Ok(wrong_field_length("locator", locator.len(), LOCATOR_LEN));
+    if req.locator.len() != LOCATOR_LEN {
+        return Err(ApiError::wrong_field_length(
+            "locator",
+            req.locator.len(),
+            LOCATOR_LEN,
+        ));
     }
-    if data.signature.is_empty() {
-        return Ok(empty_field("signature"));
+    if req.signature.is_empty() {
+        return Err(ApiError::empty_field("signature"));
     }
 
-    let (body, status) = match grpc_conn
-        .get_appointment(msgs::GetAppointmentRequest {
-            locator: locator.to_vec(),
-            signature: data.signature,
-        })
-        .await
-    {
-        Ok(r) => {
-            // This is a bit cumbersome but data is layered by gRPC due to it being either an Appointment or a Tracker
-            let body = r.into_inner();
-            let data = body.appointment_data.unwrap().appointment_data.unwrap();
-
-            let appointment_or_tracker = match data {
-                msgs::appointment_data::AppointmentData::Appointment(a) => {
-                    AppointmentOrTracker::Appointment(Appointment {
-                        locator,
-                        encrypted_blob: a.encrypted_blob,
-                        to_self_delay: a.to_self_delay,
-                    })
-                }
-                msgs::appointment_data::AppointmentData::Tracker(t) => {
-                    AppointmentOrTracker::Tracker(Tracker {
-                        locator: t.locator,
-                        dispute_txid: t.dispute_txid,
-                        penalty_txid: t.penalty_txid,
-                        penalty_rawtx: t.penalty_rawtx,
-                    })
-                }
-            };
-            (
-                warp::reply::json(&GetAppointmentResponse {
-                    appointment: appointment_or_tracker,
-                    status: AppointmentStatus::from(body.status).to_string(),
-                }),
-                StatusCode::OK,
-            )
-        }
+    let (body, status) = match grpc_conn.get_appointment(req).await {
+        Ok(r) => (reply::json(&r.into_inner()), StatusCode::OK),
         Err(s) => {
             let (error_code, status_code) = match s.code() {
                 Code::Unauthenticated | Code::NotFound => (
@@ -317,7 +186,7 @@ async fn get_appointment(
                 }
             };
             (
-                warp::reply::json(&ApiError::new(s.message().into(), error_code)),
+                reply::json(&ApiError::new(s.message().into(), error_code)),
                 status_code,
             )
         }
@@ -327,35 +196,15 @@ async fn get_appointment(
 }
 
 async fn get_subscription_info(
-    data: GetSubscriptionInfoData,
+    req: msgs::GetSubscriptionInfoRequest,
     mut grpc_conn: PublicTowerServicesClient<Channel>,
 ) -> std::result::Result<impl Reply, Rejection> {
-    if data.signature.is_empty() {
-        return Ok(empty_field("signature"));
+    if req.signature.is_empty() {
+        return Err(ApiError::empty_field("signature"));
     }
 
-    let (body, status) = match grpc_conn
-        .get_subscription_info(msgs::GetSubscriptionInfoRequest {
-            signature: data.signature,
-        })
-        .await
-    {
-        Ok(r) => {
-            let body = r.into_inner();
-            let locators = body
-                .locators
-                .iter()
-                .map(|locator| hex::encode(locator))
-                .collect();
-            (
-                warp::reply::json(&SubscriptionInfoResponse {
-                    available_slots: body.available_slots,
-                    subscription_expiry: body.subscription_expiry,
-                    locators: locators,
-                }),
-                StatusCode::OK,
-            )
-        }
+    let (body, status) = match grpc_conn.get_subscription_info(req).await {
+        Ok(r) => (reply::json(&r.into_inner()), StatusCode::OK),
         Err(s) => {
             let (error_code, status_code) = match s.code() {
                 Code::Unauthenticated => (
@@ -368,7 +217,7 @@ async fn get_subscription_info(
                 }
             };
             (
-                warp::reply::json(&ApiError::new(s.message().into(), error_code)),
+                reply::json(&ApiError::new(s.message().into(), error_code)),
                 status_code,
             )
         }
@@ -379,28 +228,31 @@ async fn get_subscription_info(
 
 fn router(
     grpc_conn: PublicTowerServicesClient<Channel>,
-) -> impl Filter<Extract = impl Reply, Error = Infallible> + Clone {
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     let register = warp::post()
         .and(warp::path("register"))
-        .and(warp::body::content_length_limit(128).and(warp::body::json()))
+        .and(warp::body::content_length_limit(REGISTER_BODY_LEN).and(warp::body::json()))
         .and(with_grpc(grpc_conn.clone()))
         .and_then(register);
 
     let add_appointment = warp::post()
         .and(warp::path("add_appointment"))
-        .and(warp::body::content_length_limit(1024).and(warp::body::json()))
+        .and(warp::body::content_length_limit(ADD_APPOINTMENT_BODY_LEN).and(warp::body::json()))
         .and(with_grpc(grpc_conn.clone()))
         .and_then(add_appointment);
 
     let get_appointment = warp::post()
         .and(warp::path("get_appointment"))
-        .and(warp::body::content_length_limit(192).and(warp::body::json()))
+        .and(warp::body::content_length_limit(GET_APPOINTMENT_BODY_LEN).and(warp::body::json()))
         .and(with_grpc(grpc_conn.clone()))
         .and_then(get_appointment);
 
     let get_subscription_info = warp::post()
         .and(warp::path("get_subscription_info"))
-        .and(warp::body::content_length_limit(128).and(warp::body::json()))
+        .and(
+            warp::body::content_length_limit(GET_SUBSCRIPTION_INFO_BODY_LEN)
+                .and(warp::body::json()),
+        )
         .and(with_grpc(grpc_conn))
         .and_then(get_subscription_info);
 
@@ -413,68 +265,34 @@ fn router(
     routes
 }
 
-async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
-    if err.is_not_found() {
-        return Ok(reply::with_status(
-            warp::reply::json(&"Not found"),
-            StatusCode::NOT_FOUND,
-        ));
+async fn handle_rejection(err: Rejection) -> Result<impl Reply, Rejection> {
+    match err.find::<warp::body::BodyDeserializeError>() {
+        Some(e) => {
+            let mut error = e
+                .source()
+                .map(|cause| cause.to_string())
+                .unwrap_or_else(|| "Invalid Body".to_string());
+
+            let error_code = if error.contains("invalid type") {
+                errors::WRONG_FIELD_TYPE
+            } else if error.contains("missing field") {
+                error = error.split(" at").take(1).next().unwrap_or(&error).into();
+                errors::MISSING_FIELD
+            } else if error.contains("Odd number of digits") | error.contains("Invalid character") {
+                errors::WRONG_FIELD_FORMAT
+            } else {
+                errors::INVALID_REQUEST_FORMAT
+            };
+            Ok(reply::with_status(
+                reply::json(&ApiError { error, error_code }),
+                StatusCode::BAD_REQUEST,
+            ))
+        }
+        None => match err.find::<ApiError>() {
+            Some(x) => Ok(reply::with_status(reply::json(x), StatusCode::BAD_REQUEST)),
+            None => Err(err),
+        },
     }
-
-    let (body, status) = if let Some(e) = err.find::<warp::body::BodyDeserializeError>() {
-        let error = e
-            .source()
-            .map(|cause| cause.to_string())
-            .unwrap_or_else(|| "Invalid Body".to_string());
-
-        let error_code = if error.contains("invalid type") {
-            errors::WRONG_FIELD_TYPE
-        } else if error.contains("missing field") {
-            errors::MISSING_FIELD
-        } else if error.contains("Odd number of digits") | error.contains("Invalid character") {
-            errors::WRONG_FIELD_FORMAT
-        } else {
-            errors::INVALID_REQUEST_FORMAT
-        };
-        (
-            warp::reply::json(&ApiError { error, error_code }),
-            StatusCode::BAD_REQUEST,
-        )
-    } else if let Some(_) = err.find::<warp::reject::PayloadTooLarge>() {
-        (
-            warp::reply::json(&ApiError::new(
-                "Payload too large".into(),
-                errors::INVALID_REQUEST_FORMAT,
-            )),
-            StatusCode::PAYLOAD_TOO_LARGE,
-        )
-    } else if let Some(_) = err.find::<warp::reject::LengthRequired>() {
-        (
-            warp::reply::json(&ApiError::new(
-                "Empty request body".into(),
-                errors::INVALID_REQUEST_FORMAT,
-            )),
-            StatusCode::LENGTH_REQUIRED,
-        )
-    } else if let Some(_) = err.find::<warp::reject::MethodNotAllowed>() {
-        (
-            warp::reply::json(&ApiError::new(
-                "Method not allowed".into(),
-                errors::INVALID_REQUEST_FORMAT,
-            )),
-            StatusCode::METHOD_NOT_ALLOWED,
-        )
-    } else {
-        (
-            warp::reply::json(&ApiError::new(
-                format!("Unexpected error: {:?}", err),
-                errors::INVALID_REQUEST_FORMAT,
-            )),
-            StatusCode::BAD_REQUEST,
-        )
-    };
-
-    Ok(reply::with_status(body, status))
 }
 
 pub async fn serve(http_bind: SocketAddr, grpc_bind: String, shutdown_signal: Listener) {
@@ -533,7 +351,7 @@ mod test_helpers {
 
     pub(crate) async fn check_api_error<'a>(
         endpoint: &str,
-        body: Option<RequestBody<'a>>,
+        body: RequestBody<'a>,
         server_addr: SocketAddr,
     ) -> (ApiError, StatusCode) {
         let grpc_conn = PublicTowerServicesClient::connect(format!(
@@ -544,22 +362,16 @@ mod test_helpers {
         .await
         .unwrap();
 
-        let req = if let Some(b) = body {
-            match b {
-                RequestBody::Json(j) => {
-                    warp::test::request().method("POST").path(endpoint).json(&j)
-                }
-                RequestBody::DoNotJsonify(j) => {
-                    warp::test::request().method("POST").path(endpoint).json(&j)
-                }
-                RequestBody::Jsonify(j) => warp::test::request()
-                    .method("POST")
-                    .path(endpoint)
-                    .json(&serde_json::from_str::<Value>(j).unwrap()),
-                RequestBody::Body(b) => warp::test::request().method("POST").path(endpoint).body(b),
+        let req = match body {
+            RequestBody::Json(j) => warp::test::request().method("POST").path(endpoint).json(&j),
+            RequestBody::DoNotJsonify(j) => {
+                warp::test::request().method("POST").path(endpoint).json(&j)
             }
-        } else {
-            warp::test::request().method("POST").path(endpoint)
+            RequestBody::Jsonify(j) => warp::test::request()
+                .method("POST")
+                .path(endpoint)
+                .json(&serde_json::from_str::<Value>(j).unwrap()),
+            RequestBody::Body(b) => warp::test::request().method("POST").path(endpoint).body(b),
         };
 
         let res = req.reply(&router(grpc_conn)).await;
@@ -606,23 +418,10 @@ mod tests_failures {
     use crate::test_utils::get_random_user_id;
 
     #[tokio::test]
-    async fn test_empty_request_body() {
-        let server_addr = run_tower_in_background().await;
-        // We use register here as an example, but error test apply every valid endpoint
-        assert_eq!(
-            check_api_error("/register", None, server_addr).await,
-            (
-                ApiError::new("Empty request body".into(), errors::INVALID_REQUEST_FORMAT),
-                StatusCode::LENGTH_REQUIRED
-            )
-        )
-    }
-
-    #[tokio::test]
     async fn test_no_json_request_body() {
         let server_addr = run_tower_in_background().await;
         let (api_error, status) =
-            check_api_error("/register", Some(RequestBody::Body("")), server_addr).await;
+            check_api_error("/register", RequestBody::Body(""), server_addr).await;
         assert!(api_error.error.contains("EOF while parsing"));
         assert_eq!(api_error.error_code, errors::INVALID_REQUEST_FORMAT);
         assert_eq!(status, StatusCode::BAD_REQUEST);
@@ -631,12 +430,8 @@ mod tests_failures {
     #[tokio::test]
     async fn test_wrong_json_request_body() {
         let server_addr = run_tower_in_background().await;
-        let (api_error, status) = check_api_error(
-            "/register",
-            Some(RequestBody::DoNotJsonify("")),
-            server_addr,
-        )
-        .await;
+        let (api_error, status) =
+            check_api_error("/register", RequestBody::DoNotJsonify(""), server_addr).await;
         assert!(api_error.error.contains("expected struct"));
         // FIXME: This may need finer catching since it's the same error as if a field cannot be deserialized from being of the wrong type.
         // May not be worth the hassle though.
@@ -647,12 +442,8 @@ mod tests_failures {
     #[tokio::test]
     async fn test_empty_json_request_body() {
         let server_addr = run_tower_in_background().await;
-        let (api_error, status) = check_api_error(
-            "/register",
-            Some(RequestBody::Jsonify(r#"{}"#)),
-            server_addr,
-        )
-        .await;
+        let (api_error, status) =
+            check_api_error("/register", RequestBody::Jsonify(r#"{}"#), server_addr).await;
         assert!(api_error.error.contains("missing field"));
         assert_eq!(api_error.error_code, errors::MISSING_FIELD);
         assert_eq!(status, StatusCode::BAD_REQUEST);
@@ -663,7 +454,7 @@ mod tests_failures {
         let server_addr = run_tower_in_background().await;
         let (api_error, status) = check_api_error(
             "/register",
-            Some(RequestBody::Jsonify(r#"{"user_id": ""}"#)),
+            RequestBody::Jsonify(r#"{"user_id": ""}"#),
             server_addr,
         )
         .await;
@@ -677,7 +468,7 @@ mod tests_failures {
         let server_addr = run_tower_in_background().await;
         let (api_error, status) = check_api_error(
             "/register",
-            Some(RequestBody::Jsonify(r#"{"user_id": "a"}"#)),
+            RequestBody::Jsonify(r#"{"user_id": "a"}"#),
             server_addr,
         )
         .await;
@@ -691,7 +482,7 @@ mod tests_failures {
         let server_addr = run_tower_in_background().await;
         let (api_error, status) =
         check_api_error("/register",  
-        Some(RequestBody::Jsonify(r#"{"user_id": "022fa2900ed7fc07b4e8ca3ea081e846245b0497944644aa78ea0b994ac22074dZ"}"#)), 
+        RequestBody::Jsonify(r#"{"user_id": "022fa2900ed7fc07b4e8ca3ea081e846245b0497944644aa78ea0b994ac22074dZ"}"#),
         server_addr
     ).await;
 
@@ -705,12 +496,12 @@ mod tests_failures {
         let server_addr = run_tower_in_background().await;
         let (api_error, status) = check_api_error(
             "/register",
-            Some(RequestBody::Jsonify(r#"{"user_id": "aa"}"#)),
+            RequestBody::Jsonify(r#"{"user_id": "aa"}"#),
             server_addr,
         )
         .await;
 
-        assert!(api_error.error.contains("Wrong user_id field size"));
+        assert!(api_error.error.contains("Wrong `user_id` field size"));
         assert_eq!(api_error.error_code, errors::WRONG_FIELD_SIZE);
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
@@ -720,7 +511,7 @@ mod tests_failures {
         let server_addr = run_tower_in_background().await;
         let (api_error, status) = check_api_error(
             "/register",
-            Some(RequestBody::DoNotJsonify(r#"{"user_id": 1}"#)),
+            RequestBody::DoNotJsonify(r#"{"user_id": 1}"#),
             server_addr,
         )
         .await;
@@ -730,35 +521,61 @@ mod tests_failures {
     }
 
     #[tokio::test]
-    async fn test_payload_too_large() {
-        let server_addr = run_tower_in_background().await;
-        let (_, status) = check_api_error(
-            "/register",
-            Some(RequestBody::Body(&format!(
-                "{}{}",
-                get_random_user_id(),
-                get_random_user_id()
-            ))),
-            server_addr,
-        )
-        .await;
-
-        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE)
-    }
-
-    #[tokio::test]
     async fn test_request_missing_field() {
         // We'll use a different endpoint here since we need a json object with more than one field
         let server_addr = run_tower_in_background().await;
         let (api_error, status) = check_api_error(
             "/add_appointment",
-            Some(RequestBody::Jsonify(r#"{"signature": "aa"}"#)),
+            RequestBody::Jsonify(r#"{"signature": "aa"}"#),
             server_addr,
         )
         .await;
         assert!(api_error.error.contains("missing field"));
         assert_eq!(api_error.error_code, errors::MISSING_FIELD);
         assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    // Tests with no json body return (passed trough handle_rejection)
+
+    #[tokio::test]
+    async fn test_empty_request_body() {
+        let server_addr = run_tower_in_background().await;
+        let grpc_conn = PublicTowerServicesClient::connect(format!(
+            "http://{}:{}",
+            server_addr.ip(),
+            server_addr.port()
+        ))
+        .await
+        .unwrap();
+
+        let res = warp::test::request()
+            .method("POST")
+            .path("/register")
+            .reply(&router(grpc_conn))
+            .await;
+
+        assert_eq!(res.status(), StatusCode::LENGTH_REQUIRED)
+    }
+
+    #[tokio::test]
+    async fn test_payload_too_large() {
+        let server_addr = run_tower_in_background().await;
+        let grpc_conn = PublicTowerServicesClient::connect(format!(
+            "http://{}:{}",
+            server_addr.ip(),
+            server_addr.port()
+        ))
+        .await
+        .unwrap();
+
+        let res = warp::test::request()
+            .method("POST")
+            .path("/register")
+            .json(&format!("{}{}", get_random_user_id(), get_random_user_id()))
+            .reply(&router(grpc_conn))
+            .await;
+
+        assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE)
     }
 
     #[tokio::test]
@@ -815,28 +632,18 @@ mod tests_methods {
     use crate::test_utils::{generate_dummy_appointment, get_random_user_id, ApiConfig, DURATION};
     use teos_common::{cryptography, UserId};
 
-    impl std::convert::From<teos_common::appointment::Appointment> for Appointment {
-        fn from(a: teos_common::appointment::Appointment) -> Self {
-            Appointment {
-                locator: a.locator.serialize(),
-                encrypted_blob: a.encrypted_blob,
-                to_self_delay: a.to_self_delay,
-            }
-        }
-    }
-
     #[tokio::test]
     async fn test_register() {
         let server_addr = run_tower_in_background().await;
-        let response = request_to_api::<RegisterData, RegisterResponse>(
+        let response = request_to_api::<msgs::RegisterRequest, msgs::RegisterResponse>(
             "/register",
-            RegisterData {
+            msgs::RegisterRequest {
                 user_id: get_random_user_id().serialize(),
             },
             server_addr,
         )
         .await;
-        assert!(matches!(response, Ok(RegisterResponse { .. })));
+        assert!(matches!(response, Ok(msgs::RegisterResponse { .. })));
     }
 
     #[tokio::test]
@@ -846,9 +653,9 @@ mod tests_methods {
         let user_id = get_random_user_id();
 
         // Register once, this should go trough and set slots to the limit
-        request_to_api::<RegisterData, RegisterResponse>(
+        request_to_api::<msgs::RegisterRequest, msgs::RegisterResponse>(
             "/register",
-            RegisterData {
+            msgs::RegisterRequest {
                 user_id: user_id.serialize(),
             },
             server_addr,
@@ -860,9 +667,9 @@ mod tests_methods {
         assert_eq!(
             check_api_error(
                 "/register",
-                Some(RequestBody::Json(serde_json::json!(RegisterData {
+                RequestBody::Json(serde_json::json!(msgs::RegisterRequest {
                     user_id: user_id.serialize(),
-                }))),
+                })),
                 server_addr,
             )
             .await,
@@ -882,9 +689,9 @@ mod tests_methods {
 
         // Register first
         let (user_sk, user_pk) = cryptography::get_random_keypair();
-        request_to_api::<RegisterData, RegisterResponse>(
+        request_to_api::<msgs::RegisterRequest, msgs::RegisterResponse>(
             "/register",
-            RegisterData {
+            msgs::RegisterRequest {
                 user_id: user_pk.serialize().to_vec(),
             },
             server_addr,
@@ -896,17 +703,17 @@ mod tests_methods {
         let appointment = generate_dummy_appointment(None).inner;
         let signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
 
-        let response = request_to_api::<AddAppointmentData, AddAppointmentResponse>(
+        let response = request_to_api::<msgs::AddAppointmentRequest, msgs::AddAppointmentResponse>(
             "/add_appointment",
-            AddAppointmentData {
-                appointment: appointment.into(),
+            msgs::AddAppointmentRequest {
+                appointment: Some(appointment.into()),
                 signature,
             },
             server_addr,
         )
         .await;
 
-        assert!(matches!(response, Ok(AddAppointmentResponse { .. })));
+        assert!(matches!(response, Ok(msgs::AddAppointmentResponse { .. })));
     }
 
     #[tokio::test]
@@ -919,10 +726,10 @@ mod tests_methods {
         assert_eq!(
             check_api_error(
                 "/add_appointment",
-                Some(RequestBody::Json(serde_json::json!(AddAppointmentData {
-                    appointment: appointment.into(),
+                RequestBody::Json(serde_json::json!(msgs::AddAppointmentRequest {
+                    appointment: Some(appointment.into()),
                     signature,
-                }))),
+                })),
                 server_addr,
             )
             .await,
@@ -944,9 +751,9 @@ mod tests_methods {
 
         // Register
         let (user_sk, user_pk) = cryptography::get_random_keypair();
-        request_to_api::<RegisterData, RegisterResponse>(
+        request_to_api::<msgs::RegisterRequest, msgs::RegisterResponse>(
             "/register",
-            RegisterData {
+            msgs::RegisterRequest {
                 user_id: user_pk.serialize().to_vec(),
             },
             server_addr,
@@ -965,10 +772,10 @@ mod tests_methods {
         assert_eq!(
             check_api_error(
                 "/add_appointment",
-                Some(RequestBody::Json(serde_json::json!(AddAppointmentData {
-                    appointment: appointment.into(),
+                RequestBody::Json(serde_json::json!(msgs::AddAppointmentRequest {
+                    appointment: Some(appointment.into()),
                     signature,
-                }))),
+                })),
                 server_addr,
             )
             .await,
@@ -988,9 +795,9 @@ mod tests_methods {
 
         // Register first
         let (user_sk, user_pk) = cryptography::get_random_keypair();
-        request_to_api::<RegisterData, RegisterResponse>(
+        request_to_api::<msgs::RegisterRequest, msgs::RegisterResponse>(
             "/register",
-            RegisterData {
+            msgs::RegisterRequest {
                 user_id: user_pk.serialize().to_vec(),
             },
             server_addr,
@@ -1002,10 +809,10 @@ mod tests_methods {
         let appointment = generate_dummy_appointment(None).inner;
         let signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
 
-        request_to_api::<AddAppointmentData, AddAppointmentResponse>(
+        request_to_api::<msgs::AddAppointmentRequest, msgs::AddAppointmentResponse>(
             "/add_appointment",
-            AddAppointmentData {
-                appointment: appointment.clone().into(),
+            msgs::AddAppointmentRequest {
+                appointment: Some(appointment.clone().into()),
                 signature,
             },
             server_addr,
@@ -1014,9 +821,9 @@ mod tests_methods {
         .unwrap();
 
         // Get it back
-        let response = request_to_api::<GetAppointmentData, GetAppointmentResponse>(
+        let response = request_to_api::<msgs::GetAppointmentRequest, msgs::GetAppointmentResponse>(
             "/get_appointment",
-            GetAppointmentData {
+            msgs::GetAppointmentRequest {
                 locator: appointment.locator.serialize(),
                 signature: cryptography::sign(
                     format!("get appointment {}", appointment.locator).as_bytes(),
@@ -1028,7 +835,7 @@ mod tests_methods {
         )
         .await;
 
-        assert!(matches!(response, Ok(GetAppointmentResponse { .. })));
+        assert!(matches!(response, Ok(msgs::GetAppointmentResponse { .. })));
     }
 
     #[tokio::test]
@@ -1043,14 +850,14 @@ mod tests_methods {
         assert_eq!(
             check_api_error(
                 "/get_appointment",
-                Some(RequestBody::Json(serde_json::json!(GetAppointmentData {
+                RequestBody::Json(serde_json::json!(msgs::GetAppointmentRequest {
                     locator: appointment.locator.serialize(),
                     signature: cryptography::sign(
                         format!("get appointment {}", appointment.locator).as_bytes(),
                         &user_sk,
                     )
                     .unwrap()
-                }))),
+                })),
                 server_addr,
             )
             .await,
@@ -1070,9 +877,9 @@ mod tests_methods {
 
         // Register first
         let (user_sk, user_pk) = cryptography::get_random_keypair();
-        request_to_api::<RegisterData, RegisterResponse>(
+        request_to_api::<msgs::RegisterRequest, msgs::RegisterResponse>(
             "/register",
-            RegisterData {
+            msgs::RegisterRequest {
                 user_id: user_pk.serialize().to_vec(),
             },
             server_addr,
@@ -1086,14 +893,14 @@ mod tests_methods {
         assert_eq!(
             check_api_error(
                 "/get_appointment",
-                Some(RequestBody::Json(serde_json::json!(GetAppointmentData {
+                RequestBody::Json(serde_json::json!(msgs::GetAppointmentRequest {
                     locator: appointment.locator.serialize(),
                     signature: cryptography::sign(
                         format!("get appointment {}", appointment.locator).as_bytes(),
                         &user_sk,
                     )
                     .unwrap()
-                }))),
+                })),
                 server_addr,
             )
             .await,
@@ -1113,9 +920,9 @@ mod tests_methods {
 
         // Register first
         let (user_sk, user_pk) = cryptography::get_random_keypair();
-        request_to_api::<RegisterData, RegisterResponse>(
+        request_to_api::<msgs::RegisterRequest, msgs::RegisterResponse>(
             "/register",
-            RegisterData {
+            msgs::RegisterRequest {
                 user_id: user_pk.serialize().to_vec(),
             },
             server_addr,
@@ -1124,17 +931,21 @@ mod tests_methods {
         .unwrap();
 
         // Get the subscription info
-        let response = request_to_api::<GetSubscriptionInfoData, SubscriptionInfoResponse>(
-            "/get_subscription_info",
-            GetSubscriptionInfoData {
-                signature: cryptography::sign("get subscription info".as_bytes(), &user_sk)
-                    .unwrap(),
-            },
-            server_addr,
-        )
-        .await;
+        let response =
+            request_to_api::<msgs::GetSubscriptionInfoRequest, msgs::GetSubscriptionInfoResponse>(
+                "/get_subscription_info",
+                msgs::GetSubscriptionInfoRequest {
+                    signature: cryptography::sign("get subscription info".as_bytes(), &user_sk)
+                        .unwrap(),
+                },
+                server_addr,
+            )
+            .await;
 
-        assert!(matches!(response, Ok(SubscriptionInfoResponse { .. })));
+        assert!(matches!(
+            response,
+            Ok(msgs::GetSubscriptionInfoResponse { .. })
+        ));
     }
 
     #[tokio::test]
@@ -1147,12 +958,10 @@ mod tests_methods {
         assert_eq!(
             check_api_error(
                 "/get_subscription_info",
-                Some(RequestBody::Json(serde_json::json!(
-                    GetSubscriptionInfoData {
-                        signature: cryptography::sign("get subscription info".as_bytes(), &user_sk)
-                            .unwrap(),
-                    }
-                ))),
+                RequestBody::Json(serde_json::json!(msgs::GetSubscriptionInfoRequest {
+                    signature: cryptography::sign("get subscription info".as_bytes(), &user_sk)
+                        .unwrap(),
+                })),
                 server_addr,
             )
             .await,

--- a/teos/src/api/http.rs
+++ b/teos/src/api/http.rs
@@ -1,0 +1,485 @@
+use serde::{Deserialize, Serialize};
+use std::convert::Infallible;
+use std::error::Error;
+use std::net::SocketAddr;
+use tonic::{transport::Channel, Code};
+use triggered::Listener;
+use warp::{http::StatusCode, reply, Filter, Rejection, Reply};
+
+use teos_common::appointment::{AppointmentStatus, LOCATOR_LEN};
+use teos_common::errors;
+use teos_common::USER_ID_LEN;
+
+use crate::protos as msgs;
+use crate::protos::public_tower_services_client::PublicTowerServicesClient;
+
+// REQUEST TYPES
+#[derive(Serialize, Deserialize, Debug)]
+struct RegisterData {
+    #[serde(with = "hex::serde")]
+    user_id: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct AddAppointmentData {
+    appointment: Appointment,
+    signature: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Appointment {
+    #[serde(with = "hex::serde")]
+    locator: Vec<u8>,
+    #[serde(with = "hex::serde")]
+    encrypted_blob: Vec<u8>,
+    to_self_delay: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct GetAppointmentData {
+    #[serde(with = "hex::serde")]
+    locator: Vec<u8>,
+    signature: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct GetSubscriptionInfoData {
+    signature: String,
+}
+
+// RESPONSE TYPES
+#[derive(Serialize, Deserialize, Debug)]
+struct RegisterResponse {
+    #[serde(with = "hex::serde")]
+    user_id: Vec<u8>,
+    available_slots: u32,
+    subscription_expiry: u32,
+    subscription_signature: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct AddAppointmentResponse {
+    #[serde(with = "hex::serde")]
+    locator: Vec<u8>,
+    start_block: u32,
+    signature: String,
+    available_slots: u32,
+    subscription_expiry: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct GetAppointmentResponse {
+    #[serde(flatten)]
+    appointment: AppointmentOrTracker,
+    status: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+enum AppointmentOrTracker {
+    #[serde(rename = "appointment")]
+    Appointment(Appointment),
+    #[serde(rename = "appointment")]
+    Tracker(Tracker),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Tracker {
+    #[serde(with = "hex::serde")]
+    locator: Vec<u8>,
+    #[serde(with = "hex::serde")]
+    dispute_txid: Vec<u8>,
+    #[serde(with = "hex::serde")]
+    penalty_txid: Vec<u8>,
+    #[serde(with = "hex::serde")]
+    penalty_rawtx: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct SubscriptionInfoResponse {
+    available_slots: u32,
+    subscription_expiry: u32,
+    locators: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub(crate) struct ApiError {
+    error: String,
+    error_code: u8,
+}
+
+impl ApiError {
+    fn new(error: String, error_code: u8) -> Self {
+        ApiError { error, error_code }
+    }
+}
+
+fn with_grpc(
+    grpc_endpoint: PublicTowerServicesClient<Channel>,
+) -> impl Filter<Extract = (PublicTowerServicesClient<Channel>,), Error = Infallible> + Clone {
+    warp::any().map(move || grpc_endpoint.clone())
+}
+
+fn empty_field(field_name: &str) -> reply::WithStatus<reply::Json> {
+    reply::with_status(
+        reply::json(&ApiError::new(
+            format!("{} field is empty", field_name),
+            errors::EMPTY_FIELD,
+        )),
+        StatusCode::BAD_REQUEST,
+    )
+}
+
+fn wrong_field_length(
+    field_name: &str,
+    field_size: usize,
+    expected_size: usize,
+) -> reply::WithStatus<reply::Json> {
+    reply::with_status(
+        warp::reply::json(&ApiError::new(
+            format!(
+                "Wrong {} field size. Expected {}, received {}",
+                field_name, expected_size, field_size
+            ),
+            errors::WRONG_FIELD_SIZE,
+        )),
+        StatusCode::BAD_REQUEST,
+    )
+}
+
+async fn register(
+    data: RegisterData,
+    mut grpc_conn: PublicTowerServicesClient<Channel>,
+) -> std::result::Result<impl Reply, Rejection> {
+    let user_id = data.user_id;
+    if user_id.is_empty() {
+        return Ok(empty_field("user_id"));
+    }
+    if user_id.len() != USER_ID_LEN {
+        return Ok(wrong_field_length("user_id", user_id.len(), USER_ID_LEN));
+    }
+
+    let (body, status) = match grpc_conn
+        .register(msgs::RegisterRequest {
+            user_id: user_id.to_vec(),
+        })
+        .await
+    {
+        Ok(r) => {
+            let body = r.into_inner();
+            (
+                warp::reply::json(&RegisterResponse {
+                    user_id: body.user_id,
+                    available_slots: body.available_slots,
+                    subscription_expiry: body.subscription_expiry,
+                    subscription_signature: body.subscription_signature,
+                }),
+                StatusCode::OK,
+            )
+        }
+        Err(s) => {
+            let error_code = match s.code() {
+                Code::InvalidArgument => errors::WRONG_FIELD_FORMAT,
+                Code::ResourceExhausted => errors::REGISTRATION_RESOURCE_EXHAUSTED,
+                _ => {
+                    log::debug!("Unexpected error ocurred: {}", s.message());
+                    errors::UNEXPECTED_ERROR
+                }
+            };
+            (
+                warp::reply::json(&ApiError::new(s.message().into(), error_code)),
+                StatusCode::BAD_REQUEST,
+            )
+        }
+    };
+
+    Ok(reply::with_status(body, status))
+}
+
+async fn add_appointment(
+    data: AddAppointmentData,
+    mut grpc_conn: PublicTowerServicesClient<Channel>,
+) -> std::result::Result<impl Reply, Rejection> {
+    let locator = data.appointment.locator;
+    if locator.is_empty() {
+        return Ok(empty_field("locator"));
+    }
+    if locator.len() != LOCATOR_LEN {
+        return Ok(wrong_field_length("locator", locator.len(), LOCATOR_LEN));
+    }
+    if data.signature.is_empty() {
+        return Ok(empty_field("signature"));
+    }
+
+    let (body, status) = match grpc_conn
+        .add_appointment(msgs::AddAppointmentRequest {
+            appointment: Some(msgs::Appointment {
+                locator: locator.to_vec(),
+                encrypted_blob: data.appointment.encrypted_blob,
+                to_self_delay: data.appointment.to_self_delay,
+            }),
+            signature: data.signature,
+        })
+        .await
+    {
+        Ok(r) => {
+            let body = r.into_inner();
+            (
+                warp::reply::json(&AddAppointmentResponse {
+                    locator: body.locator,
+                    start_block: body.start_block,
+                    signature: body.signature,
+                    available_slots: body.available_slots,
+                    subscription_expiry: body.subscription_expiry,
+                }),
+                StatusCode::OK,
+            )
+        }
+        Err(s) => {
+            let error_code = match s.code() {
+                Code::Unauthenticated => errors::INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR,
+                Code::AlreadyExists => errors::APPOINTMENT_ALREADY_TRIGGERED,
+                _ => {
+                    log::debug!("Unexpected error ocurred: {}", s.message());
+                    errors::UNEXPECTED_ERROR
+                }
+            };
+            (
+                warp::reply::json(&ApiError::new(s.message().into(), error_code)),
+                StatusCode::BAD_REQUEST,
+            )
+        }
+    };
+
+    Ok(reply::with_status(body, status))
+}
+
+async fn get_appointment(
+    data: GetAppointmentData,
+    mut grpc_conn: PublicTowerServicesClient<Channel>,
+) -> std::result::Result<impl Reply, Rejection> {
+    let locator = data.locator;
+    if locator.is_empty() {
+        return Ok(empty_field("locator"));
+    }
+    if locator.len() != LOCATOR_LEN {
+        return Ok(wrong_field_length("locator", locator.len(), LOCATOR_LEN));
+    }
+    if data.signature.is_empty() {
+        return Ok(empty_field("signature"));
+    }
+
+    let (body, status) = match grpc_conn
+        .get_appointment(msgs::GetAppointmentRequest {
+            locator: locator.to_vec(),
+            signature: data.signature,
+        })
+        .await
+    {
+        Ok(r) => {
+            // This is a bit cumbersome but data is layered by gRPC due to it being either an Appointment or a Tracker
+            let body = r.into_inner();
+            let data = body.appointment_data.unwrap().appointment_data.unwrap();
+
+            let appointment_or_tracker = match data {
+                msgs::appointment_data::AppointmentData::Appointment(a) => {
+                    AppointmentOrTracker::Appointment(Appointment {
+                        locator,
+                        encrypted_blob: a.encrypted_blob,
+                        to_self_delay: a.to_self_delay,
+                    })
+                }
+                msgs::appointment_data::AppointmentData::Tracker(t) => {
+                    AppointmentOrTracker::Tracker(Tracker {
+                        locator: t.locator,
+                        dispute_txid: t.dispute_txid,
+                        penalty_txid: t.penalty_txid,
+                        penalty_rawtx: t.penalty_rawtx,
+                    })
+                }
+            };
+            (
+                warp::reply::json(&GetAppointmentResponse {
+                    appointment: appointment_or_tracker,
+                    status: AppointmentStatus::from(body.status).to_string(),
+                }),
+                StatusCode::OK,
+            )
+        }
+        Err(s) => {
+            let (error_code, status_code) = match s.code() {
+                Code::Unauthenticated | Code::NotFound => (
+                    errors::INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR,
+                    StatusCode::NOT_FOUND,
+                ),
+                _ => {
+                    log::debug!("Unexpected error ocurred: {}", s.message());
+                    (errors::UNEXPECTED_ERROR, StatusCode::BAD_REQUEST)
+                }
+            };
+            (
+                warp::reply::json(&ApiError::new(s.message().into(), error_code)),
+                status_code,
+            )
+        }
+    };
+
+    Ok(reply::with_status(body, status))
+}
+
+async fn get_subscription_info(
+    data: GetSubscriptionInfoData,
+    mut grpc_conn: PublicTowerServicesClient<Channel>,
+) -> std::result::Result<impl Reply, Rejection> {
+    if data.signature.is_empty() {
+        return Ok(empty_field("signature"));
+    }
+
+    let (body, status) = match grpc_conn
+        .get_subscription_info(msgs::GetSubscriptionInfoRequest {
+            signature: data.signature,
+        })
+        .await
+    {
+        Ok(r) => {
+            let body = r.into_inner();
+            let locators = body
+                .locators
+                .iter()
+                .map(|locator| hex::encode(locator))
+                .collect();
+            (
+                warp::reply::json(&SubscriptionInfoResponse {
+                    available_slots: body.available_slots,
+                    subscription_expiry: body.subscription_expiry,
+                    locators: locators,
+                }),
+                StatusCode::OK,
+            )
+        }
+        Err(s) => {
+            let (error_code, status_code) = match s.code() {
+                Code::Unauthenticated => (
+                    errors::INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR,
+                    StatusCode::NOT_FOUND,
+                ),
+                _ => {
+                    log::debug!("Unexpected error ocurred: {}", s.message());
+                    (errors::UNEXPECTED_ERROR, StatusCode::BAD_REQUEST)
+                }
+            };
+            (
+                warp::reply::json(&ApiError::new(s.message().into(), error_code)),
+                status_code,
+            )
+        }
+    };
+
+    Ok(reply::with_status(body, status))
+}
+
+fn router(
+    grpc_conn: PublicTowerServicesClient<Channel>,
+) -> impl Filter<Extract = impl Reply, Error = Infallible> + Clone {
+    let register = warp::post()
+        .and(warp::path("register"))
+        .and(warp::body::content_length_limit(128).and(warp::body::json()))
+        .and(with_grpc(grpc_conn.clone()))
+        .and_then(register);
+
+    let add_appointment = warp::post()
+        .and(warp::path("add_appointment"))
+        .and(warp::body::content_length_limit(1024).and(warp::body::json()))
+        .and(with_grpc(grpc_conn.clone()))
+        .and_then(add_appointment);
+
+    let get_appointment = warp::post()
+        .and(warp::path("get_appointment"))
+        .and(warp::body::content_length_limit(192).and(warp::body::json()))
+        .and(with_grpc(grpc_conn.clone()))
+        .and_then(get_appointment);
+
+    let get_subscription_info = warp::post()
+        .and(warp::path("get_subscription_info"))
+        .and(warp::body::content_length_limit(128).and(warp::body::json()))
+        .and(with_grpc(grpc_conn))
+        .and_then(get_subscription_info);
+
+    let routes = register
+        .or(add_appointment)
+        .or(get_appointment)
+        .or(get_subscription_info)
+        .recover(|x| handle_rejection(x));
+
+    routes
+}
+
+async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
+    if err.is_not_found() {
+        return Ok(reply::with_status(
+            warp::reply::json(&"Not found"),
+            StatusCode::NOT_FOUND,
+        ));
+    }
+
+    let (body, status) = if let Some(e) = err.find::<warp::body::BodyDeserializeError>() {
+        let error = e
+            .source()
+            .map(|cause| cause.to_string())
+            .unwrap_or_else(|| "Invalid Body".to_string());
+
+        let error_code = if error.contains("invalid type") {
+            errors::WRONG_FIELD_TYPE
+        } else if error.contains("missing field") {
+            errors::MISSING_FIELD
+        } else if error.contains("Odd number of digits") | error.contains("Invalid character") {
+            errors::WRONG_FIELD_FORMAT
+        } else {
+            errors::INVALID_REQUEST_FORMAT
+        };
+        (
+            warp::reply::json(&ApiError { error, error_code }),
+            StatusCode::BAD_REQUEST,
+        )
+    } else if let Some(_) = err.find::<warp::reject::PayloadTooLarge>() {
+        (
+            warp::reply::json(&ApiError::new(
+                "Payload too large".into(),
+                errors::INVALID_REQUEST_FORMAT,
+            )),
+            StatusCode::PAYLOAD_TOO_LARGE,
+        )
+    } else if let Some(_) = err.find::<warp::reject::LengthRequired>() {
+        (
+            warp::reply::json(&ApiError::new(
+                "Empty request body".into(),
+                errors::INVALID_REQUEST_FORMAT,
+            )),
+            StatusCode::LENGTH_REQUIRED,
+        )
+    } else if let Some(_) = err.find::<warp::reject::MethodNotAllowed>() {
+        (
+            warp::reply::json(&ApiError::new(
+                "Method not allowed".into(),
+                errors::INVALID_REQUEST_FORMAT,
+            )),
+            StatusCode::METHOD_NOT_ALLOWED,
+        )
+    } else {
+        (
+            warp::reply::json(&ApiError::new(
+                format!("Unexpected error: {:?}", err),
+                errors::INVALID_REQUEST_FORMAT,
+            )),
+            StatusCode::BAD_REQUEST,
+        )
+    };
+
+    Ok(reply::with_status(body, status))
+}
+
+pub async fn serve(http_bind: SocketAddr, grpc_bind: String, shutdown_signal: Listener) {
+    let grpc_conn = PublicTowerServicesClient::connect(grpc_bind).await.unwrap();
+    let (_, server) = warp::serve(router(grpc_conn))
+        .bind_with_graceful_shutdown(http_bind, async { shutdown_signal.await });
+    server.await
+}

--- a/teos/src/api/http.rs
+++ b/teos/src/api/http.rs
@@ -483,3 +483,686 @@ pub async fn serve(http_bind: SocketAddr, grpc_bind: String, shutdown_signal: Li
         .bind_with_graceful_shutdown(http_bind, async { shutdown_signal.await });
     server.await
 }
+
+#[cfg(test)]
+mod test_helpers {
+    use super::*;
+
+    use serde::de::DeserializeOwned;
+    use serde_json::Value;
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
+    use tonic::transport::Server;
+
+    use crate::api::internal::InternalAPI;
+    use crate::protos::public_tower_services_server::PublicTowerServicesServer;
+    use crate::test_utils::{create_api_with_config, ApiConfig};
+
+    pub enum RequestBody<'a> {
+        Jsonify(&'a str),
+        DoNotJsonify(&'a str),
+        Json(Value),
+        Body(&'a str),
+    }
+
+    pub(crate) async fn run_tower_in_background_with_config(
+        api_config: ApiConfig,
+    ) -> (SocketAddr, Arc<InternalAPI>) {
+        let internal_rpc_api = create_api_with_config(api_config).await;
+        let cloned = internal_rpc_api.clone();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(PublicTowerServicesServer::new(internal_rpc_api))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+                .await
+                .unwrap();
+        });
+
+        (addr, cloned)
+    }
+
+    pub(crate) async fn run_tower_in_background() -> SocketAddr {
+        run_tower_in_background_with_config(ApiConfig::default())
+            .await
+            .0
+    }
+
+    pub(crate) async fn check_api_error<'a>(
+        endpoint: &str,
+        body: Option<RequestBody<'a>>,
+        server_addr: SocketAddr,
+    ) -> (ApiError, StatusCode) {
+        let grpc_conn = PublicTowerServicesClient::connect(format!(
+            "http://{}:{}",
+            server_addr.ip(),
+            server_addr.port()
+        ))
+        .await
+        .unwrap();
+
+        let req = if let Some(b) = body {
+            match b {
+                RequestBody::Json(j) => {
+                    warp::test::request().method("POST").path(endpoint).json(&j)
+                }
+                RequestBody::DoNotJsonify(j) => {
+                    warp::test::request().method("POST").path(endpoint).json(&j)
+                }
+                RequestBody::Jsonify(j) => warp::test::request()
+                    .method("POST")
+                    .path(endpoint)
+                    .json(&serde_json::from_str::<Value>(j).unwrap()),
+                RequestBody::Body(b) => warp::test::request().method("POST").path(endpoint).body(b),
+            }
+        } else {
+            warp::test::request().method("POST").path(endpoint)
+        };
+
+        let res = req.reply(&router(grpc_conn)).await;
+
+        (
+            serde_json::from_slice::<ApiError>(res.body()).unwrap(),
+            res.status(),
+        )
+    }
+
+    pub(crate) async fn request_to_api<B, T>(
+        endpoint: &str,
+        body: B,
+        server_addr: SocketAddr,
+    ) -> Result<T, serde_json::Error>
+    where
+        B: Serialize,
+        T: DeserializeOwned,
+    {
+        let grpc_conn = PublicTowerServicesClient::connect(format!(
+            "http://{}:{}",
+            server_addr.ip(),
+            server_addr.port()
+        ))
+        .await
+        .unwrap();
+
+        let res = warp::test::request()
+            .method("POST")
+            .path(endpoint)
+            .json(&serde_json::json!(body))
+            .reply(&router(grpc_conn))
+            .await;
+
+        serde_json::from_slice::<T>(res.body())
+    }
+}
+
+#[cfg(test)]
+mod tests_failures {
+    use super::*;
+
+    use super::test_helpers::{check_api_error, run_tower_in_background, RequestBody};
+    use crate::test_utils::get_random_user_id;
+
+    #[tokio::test]
+    async fn test_empty_request_body() {
+        let server_addr = run_tower_in_background().await;
+        // We use register here as an example, but error test apply every valid endpoint
+        assert_eq!(
+            check_api_error("/register", None, server_addr).await,
+            (
+                ApiError::new("Empty request body".into(), errors::INVALID_REQUEST_FORMAT),
+                StatusCode::LENGTH_REQUIRED
+            )
+        )
+    }
+
+    #[tokio::test]
+    async fn test_no_json_request_body() {
+        let server_addr = run_tower_in_background().await;
+        let (api_error, status) =
+            check_api_error("/register", Some(RequestBody::Body("")), server_addr).await;
+        assert!(api_error.error.contains("EOF while parsing"));
+        assert_eq!(api_error.error_code, errors::INVALID_REQUEST_FORMAT);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_json_request_body() {
+        let server_addr = run_tower_in_background().await;
+        let (api_error, status) = check_api_error(
+            "/register",
+            Some(RequestBody::DoNotJsonify("")),
+            server_addr,
+        )
+        .await;
+        assert!(api_error.error.contains("expected struct"));
+        // FIXME: This may need finer catching since it's the same error as if a field cannot be deserialized from being of the wrong type.
+        // May not be worth the hassle though.
+        assert_eq!(api_error.error_code, errors::WRONG_FIELD_TYPE);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_empty_json_request_body() {
+        let server_addr = run_tower_in_background().await;
+        let (api_error, status) = check_api_error(
+            "/register",
+            Some(RequestBody::Jsonify(r#"{}"#)),
+            server_addr,
+        )
+        .await;
+        assert!(api_error.error.contains("missing field"));
+        assert_eq!(api_error.error_code, errors::MISSING_FIELD);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_empty_field() {
+        let server_addr = run_tower_in_background().await;
+        let (api_error, status) = check_api_error(
+            "/register",
+            Some(RequestBody::Jsonify(r#"{"user_id": ""}"#)),
+            server_addr,
+        )
+        .await;
+        assert!(api_error.error.contains("field is empty"));
+        assert_eq!(api_error.error_code, errors::EMPTY_FIELD);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_field_hex_encoding_odd() {
+        let server_addr = run_tower_in_background().await;
+        let (api_error, status) = check_api_error(
+            "/register",
+            Some(RequestBody::Jsonify(r#"{"user_id": "a"}"#)),
+            server_addr,
+        )
+        .await;
+        assert!(api_error.error.contains("Odd number of digits"));
+        assert_eq!(api_error.error_code, errors::WRONG_FIELD_FORMAT);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_hex_encoding_character() {
+        let server_addr = run_tower_in_background().await;
+        let (api_error, status) =
+        check_api_error("/register",  
+        Some(RequestBody::Jsonify(r#"{"user_id": "022fa2900ed7fc07b4e8ca3ea081e846245b0497944644aa78ea0b994ac22074dZ"}"#)), 
+        server_addr
+    ).await;
+
+        assert!(api_error.error.contains("Invalid character"));
+        assert_eq!(api_error.error_code, errors::WRONG_FIELD_FORMAT);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_field_size() {
+        let server_addr = run_tower_in_background().await;
+        let (api_error, status) = check_api_error(
+            "/register",
+            Some(RequestBody::Jsonify(r#"{"user_id": "aa"}"#)),
+            server_addr,
+        )
+        .await;
+
+        assert!(api_error.error.contains("Wrong user_id field size"));
+        assert_eq!(api_error.error_code, errors::WRONG_FIELD_SIZE);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_field_type() {
+        let server_addr = run_tower_in_background().await;
+        let (api_error, status) = check_api_error(
+            "/register",
+            Some(RequestBody::DoNotJsonify(r#"{"user_id": 1}"#)),
+            server_addr,
+        )
+        .await;
+        assert!(api_error.error.contains("invalid type"));
+        assert_eq!(api_error.error_code, errors::WRONG_FIELD_TYPE);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_payload_too_large() {
+        let server_addr = run_tower_in_background().await;
+        let (_, status) = check_api_error(
+            "/register",
+            Some(RequestBody::Body(&format!(
+                "{}{}",
+                get_random_user_id(),
+                get_random_user_id()
+            ))),
+            server_addr,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE)
+    }
+
+    #[tokio::test]
+    async fn test_request_missing_field() {
+        // We'll use a different endpoint here since we need a json object with more than one field
+        let server_addr = run_tower_in_background().await;
+        let (api_error, status) = check_api_error(
+            "/add_appointment",
+            Some(RequestBody::Jsonify(r#"{"signature": "aa"}"#)),
+            server_addr,
+        )
+        .await;
+        assert!(api_error.error.contains("missing field"));
+        assert_eq!(api_error.error_code, errors::MISSING_FIELD);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_endpoint() {
+        let server_addr = run_tower_in_background().await;
+        let grpc_conn = PublicTowerServicesClient::connect(format!(
+            "http://{}:{}",
+            server_addr.ip(),
+            server_addr.port()
+        ))
+        .await
+        .unwrap();
+
+        let res = warp::test::request()
+            .method("POST")
+            .path("/")
+            .json(&"")
+            .reply(&router(grpc_conn))
+            .await;
+
+        assert_eq!(res.status(), StatusCode::NOT_FOUND)
+    }
+
+    #[tokio::test]
+    async fn test_wrong_method() {
+        let server_addr = run_tower_in_background().await;
+        let grpc_conn = PublicTowerServicesClient::connect(format!(
+            "http://{}:{}",
+            server_addr.ip(),
+            server_addr.port()
+        ))
+        .await
+        .unwrap();
+
+        let res = warp::test::request()
+            .path("/")
+            .json(&"")
+            .reply(&router(grpc_conn))
+            .await;
+
+        assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED)
+    }
+}
+
+#[cfg(test)]
+mod tests_methods {
+    use super::*;
+
+    use super::test_helpers::{
+        check_api_error, request_to_api, run_tower_in_background,
+        run_tower_in_background_with_config, RequestBody,
+    };
+    use crate::extended_appointment::UUID;
+    use crate::test_utils::{generate_dummy_appointment, get_random_user_id, ApiConfig, DURATION};
+    use teos_common::{cryptography, UserId};
+
+    impl std::convert::From<teos_common::appointment::Appointment> for Appointment {
+        fn from(a: teos_common::appointment::Appointment) -> Self {
+            Appointment {
+                locator: a.locator.serialize(),
+                encrypted_blob: a.encrypted_blob,
+                to_self_delay: a.to_self_delay,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_register() {
+        let server_addr = run_tower_in_background().await;
+        let response = request_to_api::<RegisterData, RegisterResponse>(
+            "/register",
+            RegisterData {
+                user_id: get_random_user_id().serialize(),
+            },
+            server_addr,
+        )
+        .await;
+        assert!(matches!(response, Ok(RegisterResponse { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_register_max_slots() {
+        let (server_addr, _) =
+            run_tower_in_background_with_config(ApiConfig::new(u32::MAX, DURATION)).await;
+        let user_id = get_random_user_id();
+
+        // Register once, this should go trough and set slots to the limit
+        request_to_api::<RegisterData, RegisterResponse>(
+            "/register",
+            RegisterData {
+                user_id: user_id.serialize(),
+            },
+            server_addr,
+        )
+        .await
+        .unwrap();
+
+        // Register again to get additional slots, this should fail
+        assert_eq!(
+            check_api_error(
+                "/register",
+                Some(RequestBody::Json(serde_json::json!(RegisterData {
+                    user_id: user_id.serialize(),
+                }))),
+                server_addr,
+            )
+            .await,
+            (
+                ApiError::new(
+                    "Subscription maximum slots count reached".into(),
+                    errors::REGISTRATION_RESOURCE_EXHAUSTED
+                ),
+                StatusCode::BAD_REQUEST
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_add_appointment() {
+        let server_addr = run_tower_in_background().await;
+
+        // Register first
+        let (user_sk, user_pk) = cryptography::get_random_keypair();
+        request_to_api::<RegisterData, RegisterResponse>(
+            "/register",
+            RegisterData {
+                user_id: user_pk.serialize().to_vec(),
+            },
+            server_addr,
+        )
+        .await
+        .unwrap();
+
+        // Then try to add an appointment
+        let appointment = generate_dummy_appointment(None).inner;
+        let signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+
+        let response = request_to_api::<AddAppointmentData, AddAppointmentResponse>(
+            "/add_appointment",
+            AddAppointmentData {
+                appointment: appointment.into(),
+                signature,
+            },
+            server_addr,
+        )
+        .await;
+
+        assert!(matches!(response, Ok(AddAppointmentResponse { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_add_appointment_non_registered() {
+        let server_addr = run_tower_in_background().await;
+        let (user_sk, _) = cryptography::get_random_keypair();
+        let appointment = generate_dummy_appointment(None).inner;
+        let signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+
+        assert_eq!(
+            check_api_error(
+                "/add_appointment",
+                Some(RequestBody::Json(serde_json::json!(AddAppointmentData {
+                    appointment: appointment.into(),
+                    signature,
+                }))),
+                server_addr,
+            )
+            .await,
+            (
+                ApiError::new(
+                    "Invalid signature or user does not have enough slots available".into(),
+                    errors::INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR
+                ),
+                StatusCode::BAD_REQUEST
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_add_appointment_already_triggered() {
+        // Get the InternalAPI so we can mess with the inner state
+        let (server_addr, internal_api) =
+            run_tower_in_background_with_config(ApiConfig::new(u32::MAX, DURATION)).await;
+
+        // Register
+        let (user_sk, user_pk) = cryptography::get_random_keypair();
+        request_to_api::<RegisterData, RegisterResponse>(
+            "/register",
+            RegisterData {
+                user_id: user_pk.serialize().to_vec(),
+            },
+            server_addr,
+        )
+        .await
+        .unwrap();
+
+        // Add the appointment to the Responder so it counts as triggered
+        let appointment = generate_dummy_appointment(None).inner;
+        let signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+        internal_api
+            .get_watcher()
+            .add_random_tracker_to_responder(UUID::new(appointment.locator, UserId(user_pk)));
+
+        // Try to add it via the http API
+        assert_eq!(
+            check_api_error(
+                "/add_appointment",
+                Some(RequestBody::Json(serde_json::json!(AddAppointmentData {
+                    appointment: appointment.into(),
+                    signature,
+                }))),
+                server_addr,
+            )
+            .await,
+            (
+                ApiError::new(
+                    "The provided appointment has already been triggered".into(),
+                    errors::APPOINTMENT_ALREADY_TRIGGERED
+                ),
+                StatusCode::BAD_REQUEST
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_appointment() {
+        let server_addr = run_tower_in_background().await;
+
+        // Register first
+        let (user_sk, user_pk) = cryptography::get_random_keypair();
+        request_to_api::<RegisterData, RegisterResponse>(
+            "/register",
+            RegisterData {
+                user_id: user_pk.serialize().to_vec(),
+            },
+            server_addr,
+        )
+        .await
+        .unwrap();
+
+        // Add an appointment
+        let appointment = generate_dummy_appointment(None).inner;
+        let signature = cryptography::sign(&appointment.serialize(), &user_sk).unwrap();
+
+        request_to_api::<AddAppointmentData, AddAppointmentResponse>(
+            "/add_appointment",
+            AddAppointmentData {
+                appointment: appointment.clone().into(),
+                signature,
+            },
+            server_addr,
+        )
+        .await
+        .unwrap();
+
+        // Get it back
+        let response = request_to_api::<GetAppointmentData, GetAppointmentResponse>(
+            "/get_appointment",
+            GetAppointmentData {
+                locator: appointment.locator.serialize(),
+                signature: cryptography::sign(
+                    format!("get appointment {}", appointment.locator).as_bytes(),
+                    &user_sk,
+                )
+                .unwrap(),
+            },
+            server_addr,
+        )
+        .await;
+
+        assert!(matches!(response, Ok(GetAppointmentResponse { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_get_appointment_non_registered() {
+        let server_addr = run_tower_in_background().await;
+
+        // User is not registered
+        let (user_sk, _) = cryptography::get_random_keypair();
+        // Appointment hasn't been added either, but the user check comes first
+        let appointment = generate_dummy_appointment(None).inner;
+
+        assert_eq!(
+            check_api_error(
+                "/get_appointment",
+                Some(RequestBody::Json(serde_json::json!(GetAppointmentData {
+                    locator: appointment.locator.serialize(),
+                    signature: cryptography::sign(
+                        format!("get appointment {}", appointment.locator).as_bytes(),
+                        &user_sk,
+                    )
+                    .unwrap()
+                }))),
+                server_addr,
+            )
+            .await,
+            (
+                ApiError::new(
+                    "Appointment not found".into(),
+                    errors::INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR
+                ),
+                StatusCode::NOT_FOUND
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_appointment_not_found() {
+        let server_addr = run_tower_in_background().await;
+
+        // Register first
+        let (user_sk, user_pk) = cryptography::get_random_keypair();
+        request_to_api::<RegisterData, RegisterResponse>(
+            "/register",
+            RegisterData {
+                user_id: user_pk.serialize().to_vec(),
+            },
+            server_addr,
+        )
+        .await
+        .unwrap();
+
+        // Appointment hasn't been added
+        let appointment = generate_dummy_appointment(None).inner;
+
+        assert_eq!(
+            check_api_error(
+                "/get_appointment",
+                Some(RequestBody::Json(serde_json::json!(GetAppointmentData {
+                    locator: appointment.locator.serialize(),
+                    signature: cryptography::sign(
+                        format!("get appointment {}", appointment.locator).as_bytes(),
+                        &user_sk,
+                    )
+                    .unwrap()
+                }))),
+                server_addr,
+            )
+            .await,
+            (
+                ApiError::new(
+                    "Appointment not found".into(),
+                    errors::INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR
+                ),
+                StatusCode::NOT_FOUND
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_subscription_info() {
+        let server_addr = run_tower_in_background().await;
+
+        // Register first
+        let (user_sk, user_pk) = cryptography::get_random_keypair();
+        request_to_api::<RegisterData, RegisterResponse>(
+            "/register",
+            RegisterData {
+                user_id: user_pk.serialize().to_vec(),
+            },
+            server_addr,
+        )
+        .await
+        .unwrap();
+
+        // Get the subscription info
+        let response = request_to_api::<GetSubscriptionInfoData, SubscriptionInfoResponse>(
+            "/get_subscription_info",
+            GetSubscriptionInfoData {
+                signature: cryptography::sign("get subscription info".as_bytes(), &user_sk)
+                    .unwrap(),
+            },
+            server_addr,
+        )
+        .await;
+
+        assert!(matches!(response, Ok(SubscriptionInfoResponse { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_get_subscription_info_non_registered() {
+        let server_addr = run_tower_in_background().await;
+
+        // User is not registered
+        let (user_sk, _) = cryptography::get_random_keypair();
+
+        assert_eq!(
+            check_api_error(
+                "/get_subscription_info",
+                Some(RequestBody::Json(serde_json::json!(
+                    GetSubscriptionInfoData {
+                        signature: cryptography::sign("get subscription info".as_bytes(), &user_sk)
+                            .unwrap(),
+                    }
+                ))),
+                server_addr,
+            )
+            .await,
+            (
+                ApiError::new(
+                    "User not found. Have you registered?".into(),
+                    errors::INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR
+                ),
+                StatusCode::NOT_FOUND
+            )
+        );
+    }
+}

--- a/teos/src/api/internal.rs
+++ b/teos/src/api/internal.rs
@@ -173,9 +173,10 @@ impl<'a> PublicTowerServices for Arc<InternalAPI> {
             .watcher
             .get_subscription_info(&request.into_inner().signature)
             .map_err(|e| match e {
-                GetSubscriptionInfoFailure::AuthenticationFailure => {
-                    Status::new(Code::NotFound, "User not found. Have you registered?")
-                }
+                GetSubscriptionInfoFailure::AuthenticationFailure => Status::new(
+                    Code::Unauthenticated,
+                    "User not found. Have you registered?",
+                ),
                 GetSubscriptionInfoFailure::SubscriptionExpired(x) => Status::new(
                     Code::Unauthenticated,
                     format!("Your subscription expired at {}", x),
@@ -946,7 +947,7 @@ mod tests_public_api {
             .await
         {
             Err(status) => {
-                assert_eq!(status.code(), Code::NotFound);
+                assert_eq!(status.code(), Code::Unauthenticated);
                 assert_eq!(status.message(), "User not found. Have you registered?");
             }
             _ => (),

--- a/teos/src/api/mod.rs
+++ b/teos/src/api/mod.rs
@@ -1,2 +1,43 @@
 pub mod http;
 pub mod internal;
+
+pub mod serde_status {
+    use serde::de::{self, Deserializer};
+    use serde::ser::Serializer;
+    use std::str::FromStr;
+
+    use teos_common::appointment::AppointmentStatus;
+
+    pub fn serialize<S>(status: &i32, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&AppointmentStatus::from(*status).to_string())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<i32, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StatusVisitor;
+
+        impl<'de> de::Visitor<'de> for StatusVisitor {
+            type Value = i32;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string containing the status")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let status = AppointmentStatus::from_str(v)
+                    .map_err(|_| E::custom("given status is unknown"))?;
+                Ok(status as i32)
+            }
+        }
+
+        deserializer.deserialize_any(StatusVisitor)
+    }
+}

--- a/teos/src/api/mod.rs
+++ b/teos/src/api/mod.rs
@@ -1,0 +1,2 @@
+pub mod http;
+pub mod internal;

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -236,7 +236,7 @@ impl Default for Config {
     /// user does not use any values provided here).
     fn default() -> Self {
         Self {
-            api_bind: "localhost".into(),
+            api_bind: "127.0.0.1".into(),
             api_port: 9814,
             rpc_bind: "127.0.0.1".into(),
             rpc_port: 8814,


### PR DESCRIPTION
Adds an HTTP REST API clients can connect to interact with the tower. The API serves an HTTP server and connects with the `InternalAPI` via gRPC.

The methods exposed to users match the `PublicTowerServices` from `api::internal::InternalAPI`, that is, currently:

- register
- add_appointment
- get_appointment
- get_subscription_info