### PR TITLE
Simplify apis

### DIFF
--- a/teos-common/src/errors.rs
+++ b/teos-common/src/errors.rs
@@ -10,8 +10,7 @@ pub const INVALID_SIGNATURE_OR_SUBSCRIPTION_ERROR: u8 = 7;
 /// Appointment errors [33, 64]
 pub const APPOINTMENT_FIELD_TOO_SMALL: u8 = 33;
 pub const APPOINTMENT_FIELD_TOO_BIG: u8 = 34;
-pub const APPOINTMENT_WRONG_FIELD: u8 = 35;
-pub const APPOINTMENT_ALREADY_TRIGGERED: u8 = 36;
+pub const APPOINTMENT_ALREADY_TRIGGERED: u8 = 35;
 
 /// Registration errors [65, 96]
 pub const REGISTRATION_RESOURCE_EXHAUSTED: u8 = 65;

--- a/teos/build.rs
+++ b/teos/build.rs
@@ -1,12 +1,29 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure().compile(
-        &[
-            "proto/teos/appointment.proto",
-            "proto/teos/tower_services.proto",
-            "proto/teos/user.proto",
-        ],
-        &["proto/teos"],
-    )?;
+    tonic_build::configure()
+        .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
+        .type_attribute("AppointmentData.appointment_data", "#[serde(untagged)]")
+        .field_attribute("AppointmentData.appointment_data", "#[serde(flatten)]")
+        .field_attribute("appointment_data", "#[serde(rename = \"appointment\")]")
+        .field_attribute("user_id", "#[serde(with = \"hex::serde\")]")
+        .field_attribute("locator", "#[serde(with = \"hex::serde\")]")
+        .field_attribute("encrypted_blob", "#[serde(with = \"hex::serde\")]")
+        .field_attribute("tx", "#[serde(with = \"hex::serde\")]")
+        .field_attribute(
+            "locators",
+            "#[serde(serialize_with = \"crate::api::http::serialize_locators\")]",
+        )
+        .field_attribute(
+            "GetAppointmentResponse.status",
+            "#[serde(with = \"crate::api::serde_status\")]",
+        )
+        .compile(
+            &[
+                "proto/teos/appointment.proto",
+                "proto/teos/tower_services.proto",
+                "proto/teos/user.proto",
+            ],
+            &["proto/teos"],
+        )?;
 
     Ok(())
 }

--- a/teos/src/api/mod.rs
+++ b/teos/src/api/mod.rs
@@ -1,2 +1,43 @@
 pub mod http;
 pub mod internal;
+
+pub mod serde_status {
+    use serde::de::{self, Deserializer};
+    use serde::ser::Serializer;
+    use std::str::FromStr;
+
+    use teos_common::appointment::AppointmentStatus;
+
+    pub fn serialize<S>(status: &i32, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&AppointmentStatus::from(*status).to_string())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<i32, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StatusVisitor;
+
+        impl<'de> de::Visitor<'de> for StatusVisitor {
+            type Value = i32;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string containing the status")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let status = AppointmentStatus::from_str(v)
+                    .map_err(|_| E::custom("given status is unknown"))?;
+                Ok(status as i32)
+            }
+        }
+
+        deserializer.deserialize_any(StatusVisitor)
+    }
+}


### PR DESCRIPTION
Makes proto messages derive serde so they can be reused as requests / responses for the API. WIth that, all custom messages created for `api::http` are not needed anymore and can be therefore removed.

Reworks ApiError and make rejection functions actually return a rejection (and therefor Err). Also revamps `api::htto::handle_rejection` so uncatch rejections can be passed through (which was the original intention, I just couldn't figure out how to do so).

Finally, adds serialization functions for the things need custom serde, like vector of locators (Vec<Vec<u8>> -> Vec<String>) and appointment status. The later is due to how tonic deals with enums internally.