### PR TITLE
Fixes appointment deletion when passed to the Responder

### DIFF
--- a/teos/src/responder.rs
+++ b/teos/src/responder.rs
@@ -381,7 +381,11 @@ impl Responder {
     }
 
     // DISCUSS: Check comment regarding callbacks in watcher.rs
-    // TODO: Document once modified given the above comment
+
+    /// Deletes trackers from memory and the database.
+    ///
+    /// Logs a different message depending on whether the trackers have been outdated or completed.
+    /// Removes all data related to the appointment from the database in cascade.
     fn delete_trackers(&self, uuids: HashSet<UUID>, outdated: bool) {
         let mut trackers = self.trackers.lock().unwrap();
         let mut tx_tracker_map = self.tx_tracker_map.lock().unwrap();


### PR DESCRIPTION
Appointments were not being properly deleted when passed from the `Watcher` to the `Responder`. Wether the `Responder` accepted the job or not was not being checked, meaning the `Appointment` was being deleted as if it was invalid.

This mainly means that once an appointment was passed to the `Responder` it was not only being deleted from memory, but also from the database. This produced a cascade deletion, so the entry was completely wiped from from everywhere but the `Responder`'s memory.

Adds `deleted_appointment_from_memory` to the `Watcher` and checks the `DeliveryReceipt` when handling an appointment to the `Responder`. If the appointment is accepted, then it is only deleted from the `Watcher`'s memory, delegating the cascade deletion to the `Responder` once it is finalized. 

Also documents both `delete_appointments` and `delete_trackers` (doing so earlier may have prevented this :sweat_smile:)