### PR TITLE
Removes locator from Trackers

### DIFF
--- a/teos/proto/teos/appointment.proto
+++ b/teos/proto/teos/appointment.proto
@@ -16,10 +16,9 @@ message Appointment {
 message Tracker {
   // It's the equivalent of an appointment message from data held by the Responder.
 
-  bytes locator = 1;
-  bytes dispute_txid = 2;
-  bytes penalty_txid = 3;
-  bytes penalty_rawtx = 4;
+  bytes dispute_txid = 1;
+  bytes penalty_txid = 2;
+  bytes penalty_rawtx = 3;
 }
 
 message AppointmentData {

--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -353,15 +353,8 @@ pub(crate) fn generate_dummy_appointment_with_user(
 pub fn get_random_breach() -> Breach {
     let dispute_tx = get_random_tx();
     let penalty_tx = get_random_tx();
-    let locator = Locator::new(dispute_tx.txid());
 
-    Breach::new(locator, dispute_tx, penalty_tx)
-}
-
-pub fn get_random_breach_from_locator(locator: Locator) -> Breach {
-    let mut breach = get_random_breach();
-    breach.locator = locator;
-    breach
+    Breach::new(dispute_tx, penalty_tx)
 }
 
 pub fn get_random_tracker(user_id: UserId) -> TransactionTracker {


### PR DESCRIPTION
Appointment locators where also stored as part of trackers. However, they were not necessary (nor generally used).
The only case where locators were read from trackers was when computing the `subscription_info` for a given user.
Data is now pulled from the database (through `load_locator`) in that case. This also means that `Breach` does not
need to store a locator either.