### PR TITLE
Bump teos proto version

### DIFF
--- a/teos/proto/teos/appointment.proto
+++ b/teos/proto/teos/appointment.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package teos.v1;
+package teos.v2;
 
 message Appointment {
   /*

--- a/teos/proto/teos/tower_services.proto
+++ b/teos/proto/teos/tower_services.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package teos.v1;
+package teos.v2;
 
 import "appointment.proto";
 import "user.proto";

--- a/teos/proto/teos/user.proto
+++ b/teos/proto/teos/user.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package teos.v1;
+package teos.v2;
 
 message RegisterRequest {
   // Requests a user registration with the tower. Contains the user id in the form of a compressed ECDSA public key.

--- a/teos/src/lib.rs
+++ b/teos/src/lib.rs
@@ -3,7 +3,7 @@
 //! A watchtower implementation written in Rust.
 
 pub mod protos {
-    tonic::include_proto!("teos.v1");
+    tonic::include_proto!("teos.v2");
 }
 pub mod api;
 pub mod bitcoin_cli;


### PR DESCRIPTION
rust-teos protos are not compatible with python-teos, however, they were using the same version.
Updates the version to make clear they are not compatible.