### PR TITLE
Allows dead code in test_utils::Blockchain

### DIFF
--- a/teos/src/test_utils.rs
+++ b/teos/src/test_utils.rs
@@ -68,6 +68,7 @@ pub(crate) struct Blockchain {
     malformed_headers: bool,
 }
 
+#[allow(dead_code)]
 impl Blockchain {
     pub fn default() -> Self {
         Blockchain::with_network(Network::Bitcoin)


### PR DESCRIPTION
`test_utils::Blockchain` has some methods that are currently not being used (dead code).
The code comes from `lightning-block-sync` and may be useful in the future.