### PR TITLE
Adds ChainMonitor's polling_delta as a config parameter

### DIFF
--- a/teos/src/chain_monitor.rs
+++ b/teos/src/chain_monitor.rs
@@ -50,7 +50,7 @@ where
         spv_client: SpvClient<'a, P, C, L>,
         last_known_block_header: ValidatedBlockHeader,
         dbm: Arc<Mutex<DBM>>,
-        polling_delta_sec: u64,
+        polling_delta_sec: u16,
         shutdown_signal: Listener,
         bitcoind_reachable: Arc<(Mutex<bool>, Condvar)>,
     ) -> ChainMonitor<'a, P, C, L> {
@@ -58,7 +58,7 @@ where
             spv_client,
             last_known_block_header,
             dbm,
-            polling_delta: time::Duration::from_secs(polling_delta_sec),
+            polling_delta: time::Duration::from_secs(polling_delta_sec as u64),
             shutdown_signal,
             bitcoind_reachable,
         }

--- a/teos/src/config.rs
+++ b/teos/src/config.rs
@@ -145,6 +145,7 @@ pub struct Config {
     pub subscription_duration: u32,
     pub expiry_delta: u32,
     pub min_to_self_delay: u16,
+    pub polling_delta: u16,
 
     // Internal API
     pub internal_api_bind: String,
@@ -250,6 +251,7 @@ impl Default for Config {
             subscription_duration: 4320,
             expiry_delta: 6,
             min_to_self_delay: 20,
+            polling_delta: 60,
             internal_api_bind: "127.0.0.1".into(),
             internal_api_port: 50051,
         }

--- a/teos/src/main.rs
+++ b/teos/src/main.rs
@@ -203,7 +203,7 @@ pub async fn main() {
         spv_client,
         tip,
         dbm,
-        1,
+        conf.polling_delta,
         shutdown_signal_cm,
         bitcoind_reachable.clone(),
     )


### PR DESCRIPTION
`polling_delta` must have been a config parameter. Modifies the type from `u64` to `u16` since it does not make sense to poll every more than 10 min (value is in secs).
The value has been defaulted to 1 min since polling often is recommendable.